### PR TITLE
fix cloudfront name

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -247,7 +247,7 @@ resources:
         Value:
           Fn::If:
             - CreateCustomCloudFrontDomain
-            - https://${env:CLOUDFRONT_DOMAIN_NAME, ""}/
+            - https://${self:custom.cloudfrontDomainName, ""}/
             - Fn::Join:
                 - ""
                 - - https://


### PR DESCRIPTION
Issue was in services/ui/serverless.yml there was a line trying to find the cloudfront domain name through an environment file that was not there. And defaulted to a blank string thus overwriting the parameter
