### PR TITLE
quick fix for HEDIS dropdown

### DIFF
--- a/services/ui-src/src/measures/2021/FUAAD/questions/MeasurementSpecification.tsx
+++ b/services/ui-src/src/measures/2021/FUAAD/questions/MeasurementSpecification.tsx
@@ -1,3 +1,4 @@
+import * as CUI from "@chakra-ui/react";
 import * as QMR from "components";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { Measure } from "../validation/types";
@@ -15,6 +16,11 @@ export const MeasurementSpecification = () => {
               "National Committee for Quality Assurance (NCQA)/Healthcare Effectiveness Data and Information Set (HEDIS)",
             value: "NCQA/HEDIS",
             children: [
+              <CUI.Text size="sm" pb="3">
+                NCQA, the measure steward, changed its naming convention. HEDIS
+                MY 2020 refers to a different federal fiscal year (FFY) than
+                HEDIS 2020. Please note the FFY Core Set specification above.
+              </CUI.Text>,
               <QMR.Select
                 {...register("MeasurementSpecification-HEDISVersion")}
                 label="Specify the version of HEDIS measurement year used:"
@@ -23,6 +29,14 @@ export const MeasurementSpecification = () => {
                   {
                     displayValue: "HEDIS MY 2020 (FFY 2021 Core Set Reporting)",
                     value: "HEDIS MY 2020 (FFY 2021 Core Set Reporting)",
+                  },
+                  {
+                    displayValue: "HEDIS 2020 (FFY 2020 Core Set Reporting)",
+                    value: "HEDIS 2020 (FFY 2020 Core Set Reporting)",
+                  },
+                  {
+                    displayValue: "HEDIS 2019 (FFY 2019 Core Set Reporting)",
+                    value: "HEDIS 2019 (FFY 2019 Core Set Reporting)",
                   },
                 ]}
               />,


### PR DESCRIPTION
## Purpose
Added new drop down options for HEDIS 

#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-15672


## Assorted Notes/Considerations

For FFY 2022 the list should be modified to:
HEDIS MY 2021 (FFY 2022 Core Set Reporting)
HEDIS MY 2020 (FFY 2021 Core Set Reporting)
HEDIS 2020 (FFY 2020 Core Set Reporting)
The business rule is to add the current year and drop the oldest year.

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
