### PR TITLE
Slack notification capability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,5 +109,10 @@ jobs:
       #    SLACK_COLOR: ${{job.status}}
       #    SLACK_FOOTER: ""
       #    MSG_MINIMAL: actions url,commit,ref
-         if: always()
-         
+        if: always()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,ref,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,7 @@ jobs:
           name: test_results
           path: tests/nightwatch/tests_output
       - name: Slack Notification
-        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "production"]'), env.branch_name) && failure ()
+        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "production", "ish-slack-webhook"]'), env.branch_name) && failure ()
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,19 +100,10 @@ jobs:
           name: test_results
           path: tests/nightwatch/tests_output
       - name: Slack Notification
-      #  uses: rtCamp/action-slack-notify@v2
-      #  if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "production"]'), env.branch_name) && failure ()
-      #  env:
-      #    SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #    SLACK_USERNAME: Destroy Alerts
-      #    SLACK_ICON_EMOJI: ":bell:"
-      #    SLACK_COLOR: ${{job.status}}
-      #    SLACK_FOOTER: ""
-      #    MSG_MINIMAL: actions url,commit,ref
-        if: always()
+        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "production"]'), env.branch_name) && failure ()
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          fields: repo,message,commit,ref,took # selectable (default: repo,message)
+          fields: repo,message,commit,ref # selectable (default: repo,message)
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,8 +100,7 @@ jobs:
           name: test_results
           path: tests/nightwatch/tests_output
       - name: Slack Notification
-        if: always()
-      #  if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "production"]'), env.branch_name) && failure ()
+        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "production"]'), env.branch_name) && failure ()
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,12 +100,14 @@ jobs:
           name: test_results
           path: tests/nightwatch/tests_output
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "production"]'), env.branch_name) && failure ()
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_USERNAME: Destroy Alerts
-          SLACK_ICON_EMOJI: ":bell:"
-          SLACK_COLOR: ${{job.status}}
-          SLACK_FOOTER: ""
-          MSG_MINIMAL: actions url,commit,ref
+      #  uses: rtCamp/action-slack-notify@v2
+      #  if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "production"]'), env.branch_name) && failure ()
+      #  env:
+      #    SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #    SLACK_USERNAME: Destroy Alerts
+      #    SLACK_ICON_EMOJI: ":bell:"
+      #    SLACK_COLOR: ${{job.status}}
+      #    SLACK_FOOTER: ""
+      #    MSG_MINIMAL: actions url,commit,ref
+         if: always()
+         

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,8 @@ jobs:
           name: test_results
           path: tests/nightwatch/tests_output
       - name: Slack Notification
-        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "production", "ish-slack-webhook"]'), env.branch_name) && failure ()
+        if: always()
+      #  if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "production"]'), env.branch_name) && failure ()
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
## Purpose
This PR adds the capability of sending build failure alerts to a slack channel in cmsgov workspace for master, val and prod branches.

#### Linked Issues to Close

_Links to issue(s) that are closed by this PR. Be sure to use the phrase "Closes #XXX" for each issue, so they automatically close_
Closes #431 
## Approach
A new channel (cms-mdct-qmr-github-actions-build-status) was created. All prod, val, and master build failure status will be sent to the channel


#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
