### PR TITLE
Update clear data functionality

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -22,6 +22,9 @@ Cypress.Commands.add("goToAdultMeasures", () => {
 // Visit Measures based on abbr
 Cypress.Commands.add("goToMeasure", (measure) => {
   cy.get(`[data-cy="${measure}"]`).click();
+  cy.wait(2000);
+  cy.get(`[data-cy="Clear Data"]`).click();
+  cy.get(`[data-cy="${measure}"]`).click();
 });
 
 // Correct sections visible when user is reporting data on measure


### PR DESCRIPTION
the methods.reset() method doesnt reset the checkboxes or radio buttons. Without actually rewriting those components this may be a good option, it submits an empty data object and then goes back a page. 🤷 

also added that callback to the submit functionality because i think that makes sense

and updated a cypress command to clear measures and then go back into the measure.

Anyways, if you wanted to go this direction id be good with it. Just a suggestion.