### PR TITLE
adjusted logic to fit issue with manual NDR rate numerical input

### DIFF
--- a/services/ui-src/src/components/Rate/index.tsx
+++ b/services/ui-src/src/components/Rate/index.tsx
@@ -21,7 +21,7 @@ interface Props extends QMR.InputWrapperProps {
   readOnly?: boolean;
   allowMultiple?: boolean;
   rateMultiplicationValue?: number;
-  allowAnyRate?: boolean;
+  customMask?: RegExp;
 }
 
 export const Rate = ({
@@ -30,7 +30,7 @@ export const Rate = ({
   allowMultiple = false,
   readOnly = true,
   rateMultiplicationValue = 100,
-  allowAnyRate,
+  customMask,
   ...rest
 }: Props) => {
   const {
@@ -76,7 +76,7 @@ export const Rate = ({
         : rateThatAllowsOneDecimal;
 
       prevRate[index].rate =
-        regex.test(newValue) || newValue === "" || allowAnyRate
+        regex.test(newValue) || newValue === "" || customMask?.test(newValue)
           ? newValue
           : prevRate[index].rate;
 

--- a/services/ui-src/src/measures/2021/PQI01AD/questions/OtherPerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2021/PQI01AD/questions/OtherPerformanceMeasure.tsx
@@ -4,6 +4,7 @@ import { useCustomRegister } from "hooks/useCustomRegister";
 import { Measure } from "../validation/types";
 import React from "react";
 import { useFormContext } from "react-hook-form";
+import { positiveNumbersWithMaxDecimalPlaces } from "utils/numberInputMasks";
 
 export const OtherPerformanceMeasure = () => {
   const register = useCustomRegister<Measure.Form>();
@@ -41,6 +42,7 @@ export const OtherPerformanceMeasure = () => {
                 ]}
                 name={`OtherPerformanceMeasure-Rates.${index}.rate`}
                 rateMultiplicationValue={100000}
+                customMask={positiveNumbersWithMaxDecimalPlaces(1)}
                 readOnly={false}
               />
             </CUI.Stack>

--- a/services/ui-src/src/measures/2021/PQI01AD/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2021/PQI01AD/questions/PerformanceMeasure.tsx
@@ -3,6 +3,7 @@ import * as CUI from "@chakra-ui/react";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { Measure } from "../validation/types";
 import { useFormContext } from "react-hook-form";
+import { positiveNumbersWithMaxDecimalPlaces } from "utils/numberInputMasks";
 
 export const PerformanceMeasure = () => {
   const register = useCustomRegister<Measure.Form>();
@@ -51,8 +52,8 @@ export const PerformanceMeasure = () => {
       <QMR.Rate
         readOnly={rateReadOnly}
         rates={ageRates}
-        allowAnyRate={!rateReadOnly}
         rateMultiplicationValue={100000}
+        customMask={positiveNumbersWithMaxDecimalPlaces(1)}
         {...register("PerformanceMeasure-AgeRates")}
       />
     </QMR.CoreQuestionWrapper>

--- a/services/ui-src/src/measures/2021/PQI15AD/questions/OtherPerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2021/PQI15AD/questions/OtherPerformanceMeasure.tsx
@@ -4,6 +4,7 @@ import { useCustomRegister } from "hooks/useCustomRegister";
 import { Measure } from "../validation/types";
 import React from "react";
 import { useFormContext } from "react-hook-form";
+import { positiveNumbersWithMaxDecimalPlaces } from "utils/numberInputMasks";
 
 export const OtherPerformanceMeasure = () => {
   const register = useCustomRegister<Measure.Form>();
@@ -45,6 +46,7 @@ export const OtherPerformanceMeasure = () => {
                 name={`OtherPerformanceMeasure-Rates.${index}.description`}
               />
               <QMR.Rate
+                customMask={positiveNumbersWithMaxDecimalPlaces(1)}
                 rates={[
                   {
                     id: index,

--- a/services/ui-src/src/measures/2021/PQI15AD/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2021/PQI15AD/questions/PerformanceMeasure.tsx
@@ -3,6 +3,7 @@ import * as CUI from "@chakra-ui/react";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import { Measure } from "../validation/types";
 import { useFormContext } from "react-hook-form";
+import { positiveNumbersWithMaxDecimalPlaces } from "utils/numberInputMasks";
 
 export const PerformanceMeasure = () => {
   const register = useCustomRegister<Measure.Form>();
@@ -42,7 +43,7 @@ export const PerformanceMeasure = () => {
       <QMR.Rate
         readOnly={rateReadOnly}
         rates={ageRates}
-        allowAnyRate={!rateReadOnly}
+        customMask={positiveNumbersWithMaxDecimalPlaces(1)}
         rateMultiplicationValue={100000}
         {...register("PerformanceMeasure-AgeRates")}
       />


### PR DESCRIPTION
Per our conversation with Dani this morning, the NDR manual sets needed to be slightly different with numerical numbers potentially greater than 100 with only one number after the decimal point.
