### PR TITLE
Update cypress env vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,7 +141,6 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
-          env: true
         env:
           CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
           CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
@@ -265,7 +264,6 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
-          env: true
         env:
           CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
           CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
@@ -363,7 +361,6 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
-          env: true
         env:
           CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
           CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
@@ -468,7 +465,6 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
-          env: true
         env:
           CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
           CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
@@ -593,7 +589,6 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
-          env: true
         env:
           CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
           CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,10 +137,10 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          TEST_USER_1: ${{ secrets.TEST_USER_1 }}
-          TEST_USER_2: ${{ secrets.TEST_USER_2 }}
-          TEST_USER_3: ${{ secrets.TEST_USER_3 }}
-          TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
+          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+          CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -255,10 +255,10 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          TEST_USER_1: ${{ secrets.TEST_USER_1 }}
-          TEST_USER_2: ${{ secrets.TEST_USER_2 }}
-          TEST_USER_3: ${{ secrets.TEST_USER_3 }}
-          TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
+          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+          CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -347,10 +347,10 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          TEST_USER_1: ${{ secrets.TEST_USER_1 }}
-          TEST_USER_2: ${{ secrets.TEST_USER_2 }}
-          TEST_USER_3: ${{ secrets.TEST_USER_3 }}
-          TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
+          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+          CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -446,10 +446,10 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          TEST_USER_1: ${{ secrets.TEST_USER_1 }}
-          TEST_USER_2: ${{ secrets.TEST_USER_2 }}
-          TEST_USER_3: ${{ secrets.TEST_USER_3 }}
-          TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
+          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+          CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -565,7 +565,7 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          TEST_USER_1: ${{ secrets.TEST_USER_1 }}
-          TEST_USER_2: ${{ secrets.TEST_USER_2 }}
-          TEST_USER_3: ${{ secrets.TEST_USER_3 }}
-          TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
+          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+          CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,6 +136,7 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
         env:
           CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
           CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
@@ -254,6 +255,7 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
         env:
           CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
           CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
@@ -346,6 +348,7 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
         env:
           CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
           CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
@@ -445,6 +448,7 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
         env:
           CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
           CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
@@ -564,6 +568,7 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
         env:
           CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
           CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,14 +127,14 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Get Test Users
-        run: |
-          pushd services
-          export CYPRESS_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
-          export CYPRESS_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
-          export CYPRESS_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
-          export CYPRESS_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
-          popd
+      # - name: Get Test Users
+      #   run: |
+      #     pushd services
+      #     export CYPRESS_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
+      #     export CYPRESS_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
+      #     export CYPRESS_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
+      #     export CYPRESS_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
+      #     popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -145,11 +145,11 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
           env: true
-        # env:
-        #   CYPRESS_USER_1: ${{ env.CYPRESS_USER_1 }}
-        #   CYPRESS_USER_2: ${{ env.CYPRESS_USER_2 }}
-        #   CYPRESS_USER_3: ${{ env.CYPRESS_USER_3 }}
-        #   CYPRESS_PASSWORD_1: ${{ env.CYPRESS_PASSWORD_1 }}
+        env:
+          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+          CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
         # env:
         #   CYPRESS_USER_1: stateuser1@test.com
         #   CYPRESS_USER_2: stateuser2@test.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -594,5 +594,3 @@ jobs:
           CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
           CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
           CYPRESS_USER_PW: ${{ secrets.CYPRESS_USER_PW }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,27 @@ on:
       - "!skipci*"
 
 jobs:
+  set-env:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set branch_name
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
+            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
+          else
+            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          fi
+      - name: Validate branch name
+        run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
+      - name: Make Test Config
+        run: |
+          pushd tests/cypress
+          sh configureLocal.sh $branch_name
+          popd
+
   deploy:
     runs-on: ubuntu-latest
+    needs: set-env
     env:
       SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
     steps:
@@ -127,11 +146,11 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      # - name: Make Test Config
-      #   run: |
-      #     pushd tests/cypress
-      #     sh configureLocal.sh $branch_name
-      #     popd
+      - name: Make Test Config
+        run: |
+          pushd tests/cypress
+          sh configureLocal.sh $branch_name
+          popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -249,11 +268,11 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      # - name: Make Test Config
-      #   run: |
-      #     pushd tests/cypress
-      #     sh configureLocal.sh $branch_name
-      #     popd
+      - name: Make Test Config
+        run: |
+          pushd tests/cypress
+          sh configureLocal.sh $branch_name
+          popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -346,11 +365,11 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      # - name: Make Test Config
-      #   run: |
-      #     pushd tests/cypress
-      #     sh configureLocal.sh $branch_name
-      #     popd
+      - name: Make Test Config
+        run: |
+          pushd tests/cypress
+          sh configureLocal.sh $branch_name
+          popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -450,11 +469,11 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      # - name: Make Test Config
-      #   run: |
-      #     pushd tests/cypress
-      #     sh configureLocal.sh $branch_name
-      #     popd
+      - name: Make Test Config
+        run: |
+          pushd tests/cypress
+          sh configureLocal.sh $branch_name
+          popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -575,11 +594,11 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      # - name: Make Test Config
-      #   run: |
-      #     pushd tests/cypress
-      #     sh configureLocal.sh $branch_name
-      #     popd
+      - name: Make Test Config
+        run: |
+          pushd tests/cypress
+          sh configureLocal.sh $branch_name
+          popd
       - name: Check Project A11y
         uses: cypress-io/github-action@v2.11.7
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,14 +127,6 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      # - name: Get Test Users
-      #   run: |
-      #     pushd services
-      #     export CYPRESS_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
-      #     export CYPRESS_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
-      #     export CYPRESS_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
-      #     export CYPRESS_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
-      #     popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -146,15 +138,10 @@ jobs:
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
           env: true
         env:
-          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-          CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
-        # env:
-        #   CYPRESS_USER_1: stateuser1@test.com
-        #   CYPRESS_USER_2: stateuser2@test.com
-        #   CYPRESS_USER_3: stateuser3@test.com
-        #   CYPRESS_PASSWORD_1: p@55W0rd!
+          CYPRESS_TEST_USER_1: ${{ secrets.CYPRESS_TEST_USER_1 }}
+          CYPRESS_TEST_USER_2: ${{ secrets.CYPRESS_TEST_USER_2 }}
+          CYPRESS_TEST_USER_3: ${{ secrets.CYPRESS_TEST_USER_3 }}
+          CYPRESS_TEST_PASSWORD_1: ${{ secrets.CYPRESS_TEST_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -171,419 +158,419 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  # test-adult-measures:
-  #   name: Test Adult Measures
-  #   needs: deploy
-  #   if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val' }}
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       containers: [
-  #           AMMAD.spec.js,
-  #           AMRAD.spec.js,
-  #           BCSAD.spec.js,
-  #           CBPAD.spec.js,
-  #           CCPAD.spec.js,
-  #           CCSAD.spec.js,
-  #           CCWAD.spec.js,
-  #           CDFAD.spec.js,
-  #           CHLAD.spec.js,
-  #           COBAD.spec.js,
-  #           CPAAD.spec.js,
-  #           FUAAD.spec.js,
-  #           FUHAD.spec.js,
-  #           FUMAD.spec.js,
-  #           FVAAD.spec.js,
-  #           HPCAD.spec.js,
-  #           HPCMIAD.spec.js,
-  #           HVLAD.spec.js,
-  #           MSCAD.spec.js,
-  #           # NCIDDSAD.spec.js,
-  #           OHDAD.spec.js,
-  #           OUDAD.spec.js,
-  #           PC01AD.spec.js,
-  #           PCRAD.spec.js,
-  #           PPCAD.spec.js,
-  #           # PQI01AD.spec.js,
-  #           PQI05AD.spec.js,
-  #           PQI08AD.spec.js,
-  #           PQI15AD.spec.js,
-  #           QUALIFIERS_adult.spec.feature,
-  #           SAAAD.spec.js,
-  #           SSDAD.spec.js,
-  #         ]
-  #   steps:
-  #     - name: set branch_name
-  #       run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-  #     - uses: actions/checkout@v1
-  #     - name: set branch specific variable names
-  #       run: ./.github/build_vars.sh set_names
-  #     - name: set variable values
-  #       run: ./.github/build_vars.sh set_values
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-  #         INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
-  #         STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-  #         COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
-  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #     - uses: actions/setup-node@v1
-  #       with:
-  #         node-version: "12.x"
-  #     - name: Combine yarn.lock files to single file
-  #       run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
-  #     - name: cache service dependencies
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           services/app-api/node_modules
-  #           services/uploads/node_modules
-  #           services/stream-functions/node_modules
-  #           services/ui/node_modules
-  #           services/ui-auth/node_modules
-  #           services/ui-src/node_modules
-  #           node_modules
-  #         key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
-  #     - name: Install dependencies
-  #       run: yarn install --frozen-lockfile
-  #     - name: set path
-  #       run: |
-  #         echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-  #     - name: Endpoint
-  #       run: |
-  #         pushd services
-  #         export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
-  #         echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
-  #         echo "Application endpoint: $APPLICATION_ENDPOINT"
-  #         popd
-  #     - name: Run Cypress Tests
-  #       uses: cypress-io/github-action@v2.11.7
-  #       with:
-  #         record: false
-  #         working-directory: tests/cypress
-  #         spec: cypress/integration/measures/${{ matrix.containers }}
-  #         browser: chrome
-  #         headless: true
-  #         config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
-  #         wait-on: ${{ env.APPLICATION_ENDPOINT }}
-  #         env: true
-  #       env:
-  #         CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-  #         CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-  #         CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-  #         CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
-  #     - name: Upload screenshots
-  #       uses: actions/upload-artifact@v2
-  #       if: failure()
-  #       with:
-  #         name: cypress-screenshots
-  #         path: tests/cypress/screenshots/
+  test-adult-measures:
+    name: Test Adult Measures
+    needs: deploy
+    if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [
+            AMMAD.spec.js,
+            AMRAD.spec.js,
+            BCSAD.spec.js,
+            CBPAD.spec.js,
+            CCPAD.spec.js,
+            CCSAD.spec.js,
+            CCWAD.spec.js,
+            CDFAD.spec.js,
+            CHLAD.spec.js,
+            COBAD.spec.js,
+            CPAAD.spec.js,
+            FUAAD.spec.js,
+            FUHAD.spec.js,
+            FUMAD.spec.js,
+            FVAAD.spec.js,
+            HPCAD.spec.js,
+            HPCMIAD.spec.js,
+            HVLAD.spec.js,
+            MSCAD.spec.js,
+            # NCIDDSAD.spec.js,
+            OHDAD.spec.js,
+            OUDAD.spec.js,
+            PC01AD.spec.js,
+            PCRAD.spec.js,
+            PPCAD.spec.js,
+            # PQI01AD.spec.js,
+            PQI05AD.spec.js,
+            PQI08AD.spec.js,
+            PQI15AD.spec.js,
+            QUALIFIERS_adult.spec.feature,
+            SAAAD.spec.js,
+            SSDAD.spec.js,
+          ]
+    steps:
+      - name: set branch_name
+        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - uses: actions/checkout@v1
+      - name: set branch specific variable names
+        run: ./.github/build_vars.sh set_names
+      - name: set variable values
+        run: ./.github/build_vars.sh set_values
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+          INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
+          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+          COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - name: Combine yarn.lock files to single file
+        run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
+      - name: cache service dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            services/app-api/node_modules
+            services/uploads/node_modules
+            services/stream-functions/node_modules
+            services/ui/node_modules
+            services/ui-auth/node_modules
+            services/ui-src/node_modules
+            node_modules
+          key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: set path
+        run: |
+          echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
+      - name: Endpoint
+        run: |
+          pushd services
+          export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
+          echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
+          echo "Application endpoint: $APPLICATION_ENDPOINT"
+          popd
+      - name: Run Cypress Tests
+        uses: cypress-io/github-action@v2.11.7
+        with:
+          record: false
+          working-directory: tests/cypress
+          spec: cypress/integration/measures/${{ matrix.containers }}
+          browser: chrome
+          headless: true
+          config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
+          wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
+        env:
+          CYPRESS_TEST_USER_1: ${{ secrets.CYPRESS_TEST_USER_1 }}
+          CYPRESS_TEST_USER_2: ${{ secrets.CYPRESS_TEST_USER_2 }}
+          CYPRESS_TEST_USER_3: ${{ secrets.CYPRESS_TEST_USER_3 }}
+          CYPRESS_TEST_PASSWORD_1: ${{ secrets.CYPRESS_TEST_PASSWORD_1 }}
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: tests/cypress/screenshots/
 
-  #     - name: Slack Notification
-  #       if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
-  #       uses: 8398a7/action-slack@v3
-  #       with:
-  #         status: ${{ job.status }}
-  #         fields: repo,message,commit,ref # selectable (default: repo,message)
-  #       env:
-  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Slack Notification
+        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,ref # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  # test-child-measures:
-  #   name: Test Child Measures
-  #   needs: setup-ch-tests
-  #   if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val' }}
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       containers:
-  #         [
-  #           AMRCH.spec.js,
-  #           CISCH.spec.js,
-  #           CPCCH.spec.js,
-  #           FUHCH.spec.js,
-  #           QUALIFIERS_child.spec.js,
-  #         ]
-  #   steps:
-  #     - name: set branch_name
-  #       run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-  #     - uses: actions/checkout@v1
-  #     - name: set branch specific variable names
-  #       run: ./.github/build_vars.sh set_names
-  #     - name: set variable values
-  #       run: ./.github/build_vars.sh set_values
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-  #         INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
-  #         STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-  #         COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
-  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #     - uses: actions/setup-node@v1
-  #       with:
-  #         node-version: "12.x"
-  #     - name: Combine yarn.lock files to single file
-  #       run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
-  #     - name: cache service dependencies
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           services/app-api/node_modules
-  #           services/uploads/node_modules
-  #           services/stream-functions/node_modules
-  #           services/ui/node_modules
-  #           services/ui-auth/node_modules
-  #           services/ui-src/node_modules
-  #           node_modules
-  #         key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
-  #     - name: Install dependencies
-  #       run: yarn install --frozen-lockfile
-  #     - name: set path
-  #       run: |
-  #         echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-  #     - name: Endpoint
-  #       run: |
-  #         pushd services
-  #         export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
-  #         echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
-  #         echo "Application endpoint: $APPLICATION_ENDPOINT"
-  #         popd
-  #     - name: Run Cypress Tests
-  #       uses: cypress-io/github-action@v2.11.7
-  #       with:
-  #         record: false
-  #         working-directory: tests/cypress
-  #         spec: cypress/integration/measures/${{ matrix.containers }}
-  #         browser: chrome
-  #         headless: true
-  #         config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
-  #         wait-on: ${{ env.APPLICATION_ENDPOINT }}
-  #         env: true
-  #       env:
-  #         CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-  #         CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-  #         CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-  #         CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
-  #     - name: Upload screenshots
-  #       uses: actions/upload-artifact@v2
-  #       if: failure()
-  #       with:
-  #         name: cypress-screenshots
-  #         path: tests/cypress/screenshots/
+  test-child-measures:
+    name: Test Child Measures
+    needs: setup-ch-tests
+    if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        containers:
+          [
+            AMRCH.spec.js,
+            CISCH.spec.js,
+            CPCCH.spec.js,
+            FUHCH.spec.js,
+            QUALIFIERS_child.spec.js,
+          ]
+    steps:
+      - name: set branch_name
+        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - uses: actions/checkout@v1
+      - name: set branch specific variable names
+        run: ./.github/build_vars.sh set_names
+      - name: set variable values
+        run: ./.github/build_vars.sh set_values
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+          INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
+          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+          COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - name: Combine yarn.lock files to single file
+        run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
+      - name: cache service dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            services/app-api/node_modules
+            services/uploads/node_modules
+            services/stream-functions/node_modules
+            services/ui/node_modules
+            services/ui-auth/node_modules
+            services/ui-src/node_modules
+            node_modules
+          key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: set path
+        run: |
+          echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
+      - name: Endpoint
+        run: |
+          pushd services
+          export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
+          echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
+          echo "Application endpoint: $APPLICATION_ENDPOINT"
+          popd
+      - name: Run Cypress Tests
+        uses: cypress-io/github-action@v2.11.7
+        with:
+          record: false
+          working-directory: tests/cypress
+          spec: cypress/integration/measures/${{ matrix.containers }}
+          browser: chrome
+          headless: true
+          config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
+          wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
+        env:
+          CYPRESS_TEST_USER_1: ${{ secrets.CYPRESS_TEST_USER_1 }}
+          CYPRESS_TEST_USER_2: ${{ secrets.CYPRESS_TEST_USER_2 }}
+          CYPRESS_TEST_USER_3: ${{ secrets.CYPRESS_TEST_USER_3 }}
+          CYPRESS_TEST_PASSWORD_1: ${{ secrets.CYPRESS_TEST_PASSWORD_1 }}
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: tests/cypress/screenshots/
 
-  #     - name: Slack Notification
-  #       if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
-  #       uses: 8398a7/action-slack@v3
-  #       with:
-  #         status: ${{ job.status }}
-  #         fields: repo,message,commit,ref # selectable (default: repo,message)
-  #       env:
-  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Slack Notification
+        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,ref # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  # test-features:
-  #   name: Test Features
-  #   needs: test-adult-measures
-  #   if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val'}}
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       containers:
-  #         [
-  #           add_validation_to_rate_when_user_selects_multiple_Data_Sources.spec.js,
-  #           adding_link_to_combined_rates_component.spec.js,
-  #           data_source_rate_to_auto_calculate_in_OPM.spec.js,
-  #           combined_rates_validation_warnings.spec.js,
-  #           date_range_adjustment.spec.js,
-  #           FAQ.spec.js,
-  #           logo.spec.feature,
-  #           measure_validation_error_creation_updates.spec.feature,
-  #           NDR_validation_updates.spec.js,
-  #           reporting_in_FY21_tag_for_alt_data_sources.spec.js,
-  #           restructuring_data_source_text_boxes.spec.js,
-  #           update_user_auth_handling_in_ui.spec.feature,
-  #         ]
-  #   steps:
-  #     - name: set branch_name
-  #       run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-  #     - uses: actions/checkout@v1
-  #     - name: set branch specific variable names
-  #       run: ./.github/build_vars.sh set_names
-  #     - name: set variable values
-  #       run: ./.github/build_vars.sh set_values
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-  #         INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
-  #         STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-  #         COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
-  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #     - uses: actions/setup-node@v1
-  #       with:
-  #         node-version: "12.x"
-  #     - name: Combine yarn.lock files to single file
-  #       run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
-  #     - name: cache service dependencies
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           services/app-api/node_modules
-  #           services/uploads/node_modules
-  #           services/stream-functions/node_modules
-  #           services/ui/node_modules
-  #           services/ui-auth/node_modules
-  #           services/ui-src/node_modules
-  #           node_modules
-  #         key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
-  #     - name: Install dependencies
-  #       run: yarn install --frozen-lockfile
-  #     - name: set path
-  #       run: |
-  #         echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-  #     - name: Endpoint
-  #       run: |
-  #         pushd services
-  #         export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
-  #         echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
-  #         echo "Application endpoint: $APPLICATION_ENDPOINT"
-  #         popd
-  #     - name: Run Cypress Tests
-  #       uses: cypress-io/github-action@v2.11.7
-  #       with:
-  #         record: false
-  #         working-directory: tests/cypress
-  #         spec: cypress/integration/features/${{ matrix.containers }}
-  #         browser: chrome
-  #         headless: true
-  #         config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
-  #         wait-on: ${{ env.APPLICATION_ENDPOINT }}
-  #         env: true
-  #       env:
-  #         CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-  #         CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-  #         CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-  #         CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
-  #     - name: Upload screenshots
-  #       uses: actions/upload-artifact@v2
-  #       if: failure()
-  #       with:
-  #         name: cypress-screenshots
-  #         path: tests/cypress/screenshots/
+  test-features:
+    name: Test Features
+    needs: test-adult-measures
+    if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val'}}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        containers:
+          [
+            add_validation_to_rate_when_user_selects_multiple_Data_Sources.spec.js,
+            adding_link_to_combined_rates_component.spec.js,
+            data_source_rate_to_auto_calculate_in_OPM.spec.js,
+            combined_rates_validation_warnings.spec.js,
+            date_range_adjustment.spec.js,
+            FAQ.spec.js,
+            logo.spec.feature,
+            measure_validation_error_creation_updates.spec.feature,
+            NDR_validation_updates.spec.js,
+            reporting_in_FY21_tag_for_alt_data_sources.spec.js,
+            restructuring_data_source_text_boxes.spec.js,
+            update_user_auth_handling_in_ui.spec.feature,
+          ]
+    steps:
+      - name: set branch_name
+        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - uses: actions/checkout@v1
+      - name: set branch specific variable names
+        run: ./.github/build_vars.sh set_names
+      - name: set variable values
+        run: ./.github/build_vars.sh set_values
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+          INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
+          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+          COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - name: Combine yarn.lock files to single file
+        run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
+      - name: cache service dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            services/app-api/node_modules
+            services/uploads/node_modules
+            services/stream-functions/node_modules
+            services/ui/node_modules
+            services/ui-auth/node_modules
+            services/ui-src/node_modules
+            node_modules
+          key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: set path
+        run: |
+          echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
+      - name: Endpoint
+        run: |
+          pushd services
+          export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
+          echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
+          echo "Application endpoint: $APPLICATION_ENDPOINT"
+          popd
+      - name: Run Cypress Tests
+        uses: cypress-io/github-action@v2.11.7
+        with:
+          record: false
+          working-directory: tests/cypress
+          spec: cypress/integration/features/${{ matrix.containers }}
+          browser: chrome
+          headless: true
+          config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
+          wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
+        env:
+          CYPRESS_TEST_USER_1: ${{ secrets.CYPRESS_TEST_USER_1 }}
+          CYPRESS_TEST_USER_2: ${{ secrets.CYPRESS_TEST_USER_2 }}
+          CYPRESS_TEST_USER_3: ${{ secrets.CYPRESS_TEST_USER_3 }}
+          CYPRESS_TEST_PASSWORD_1: ${{ secrets.CYPRESS_TEST_PASSWORD_1 }}
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: tests/cypress/screenshots/
 
-  #     - name: Slack Notification
-  #       if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
-  #       uses: 8398a7/action-slack@v3
-  #       with:
-  #         status: ${{ job.status }}
-  #         fields: repo,message,commit,ref # selectable (default: repo,message)
-  #       env:
-  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Slack Notification
+        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,ref # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  # a11y-tests:
-  #   name: Test Ally
-  #   needs: [test-adult-measures, test-child-measures]
-  #   if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val' }}
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       containers: [
-  #           ammadPage,
-  #           # amradPage,
-  #           # bcsadPage,
-  #           # cbpadPage,
-  #           # ccpadPage,
-  #           # ccsadPage,
-  #           # ccwadPage,
-  #           # cdfadPage,
-  #           # chladPage,
-  #           # cobadPage,
-  #           # commonPages,
-  #           # cpaadPage,
-  #           # faqPage,
-  #           # fuadPage,
-  #           # fuhadPage,
-  #           # fumadPage,
-  #           # fvaadPage,
-  #           # hpcadPage,
-  #           # hpcmiadPage,
-  #           # hvladPage,
-  #           # ietadPage,
-  #           # mscadPage,
-  #           # nciddsPage,
-  #           # ohdadPage,
-  #           # oudadPage,
-  #           # pc01adPage,
-  #           # pcradPage,
-  #           # ppcadPage,
-  #           # pqi01adPage,
-  #           # pqi05adPage,
-  #           # pqi08adPage,
-  #           # pqi15adPage,
-  #           # ssaadPage,
-  #           # ssdadPage,
-  #         ]
-  #   steps:
-  #     - name: set branch_name
-  #       run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-  #     - uses: actions/checkout@v1
-  #     - name: set branch specific variable names
-  #       run: ./.github/build_vars.sh set_names
-  #     - name: set variable values
-  #       run: ./.github/build_vars.sh set_values
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-  #         INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
-  #         STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-  #         COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
-  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #     - uses: actions/setup-node@v1
-  #       with:
-  #         node-version: "12.x"
-  #     - name: Combine yarn.lock files to single file
-  #       run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
-  #     - name: cache service dependencies
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           services/app-api/node_modules
-  #           services/uploads/node_modules
-  #           services/stream-functions/node_modules
-  #           services/ui/node_modules
-  #           services/ui-auth/node_modules
-  #           services/ui-src/node_modules
-  #           node_modules
-  #         key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
-  #     - name: Install dependencies
-  #       run: yarn install --frozen-lockfile
-  #     - name: set path
-  #       run: |
-  #         echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-  #     - name: Endpoint
-  #       run: |
-  #         pushd services
-  #         export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
-  #         echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
-  #         echo "Application endpoint: $APPLICATION_ENDPOINT"
-  #         popd
-  #     - name: Check Project A11y
-  #       uses: cypress-io/github-action@v2.11.7
-  #       with:
-  #         working-directory: tests/cypress
-  #         spec: cypress/integration/a11y/${{ matrix.containers }}.spec.js
-  #         browser: chrome
-  #         headless: true
-  #         config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
-  #         wait-on: ${{ env.APPLICATION_ENDPOINT }}
-  #         env: true
-  #       env:
-  #         CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-  #         CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-  #         CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-  #         CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
+  a11y-tests:
+    name: Test Ally
+    needs: [test-adult-measures, test-child-measures]
+    if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [
+            ammadPage,
+            # amradPage,
+            # bcsadPage,
+            # cbpadPage,
+            # ccpadPage,
+            # ccsadPage,
+            # ccwadPage,
+            # cdfadPage,
+            # chladPage,
+            # cobadPage,
+            # commonPages,
+            # cpaadPage,
+            # faqPage,
+            # fuadPage,
+            # fuhadPage,
+            # fumadPage,
+            # fvaadPage,
+            # hpcadPage,
+            # hpcmiadPage,
+            # hvladPage,
+            # ietadPage,
+            # mscadPage,
+            # nciddsPage,
+            # ohdadPage,
+            # oudadPage,
+            # pc01adPage,
+            # pcradPage,
+            # ppcadPage,
+            # pqi01adPage,
+            # pqi05adPage,
+            # pqi08adPage,
+            # pqi15adPage,
+            # ssaadPage,
+            # ssdadPage,
+          ]
+    steps:
+      - name: set branch_name
+        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - uses: actions/checkout@v1
+      - name: set branch specific variable names
+        run: ./.github/build_vars.sh set_names
+      - name: set variable values
+        run: ./.github/build_vars.sh set_values
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+          INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
+          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+          COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - name: Combine yarn.lock files to single file
+        run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
+      - name: cache service dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            services/app-api/node_modules
+            services/uploads/node_modules
+            services/stream-functions/node_modules
+            services/ui/node_modules
+            services/ui-auth/node_modules
+            services/ui-src/node_modules
+            node_modules
+          key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: set path
+        run: |
+          echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
+      - name: Endpoint
+        run: |
+          pushd services
+          export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
+          echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
+          echo "Application endpoint: $APPLICATION_ENDPOINT"
+          popd
+      - name: Check Project A11y
+        uses: cypress-io/github-action@v2.11.7
+        with:
+          working-directory: tests/cypress
+          spec: cypress/integration/a11y/${{ matrix.containers }}.spec.js
+          browser: chrome
+          headless: true
+          config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
+          wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
+        env:
+          CYPRESS_TEST_USER_1: ${{ secrets.CYPRESS_TEST_USER_1 }}
+          CYPRESS_TEST_USER_2: ${{ secrets.CYPRESS_TEST_USER_2 }}
+          CYPRESS_TEST_USER_3: ${{ secrets.CYPRESS_TEST_USER_3 }}
+          CYPRESS_TEST_PASSWORD_1: ${{ secrets.CYPRESS_TEST_PASSWORD_1 }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,6 +132,7 @@ jobs:
           pushd services
           export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
           echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
+          echo "TEst User 1: $TEST_USER_1"
           export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
           echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
           export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
@@ -261,6 +262,7 @@ jobs:
           pushd services
           export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
           echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
+          echo "TEst User 1: $TEST_USER_1"
           export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
           echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
           export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
@@ -365,6 +367,7 @@ jobs:
           pushd services
           export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
           echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
+          echo "TEst User 1: $TEST_USER_1"
           export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
           echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
           export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
@@ -476,6 +479,7 @@ jobs:
           pushd services
           export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
           echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
+          echo "TEst User 1: $TEST_USER_1"
           export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
           echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
           export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
@@ -608,6 +612,7 @@ jobs:
           pushd services
           export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
           echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
+          echo "TEst User 1: $TEST_USER_1"
           export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
           echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
           export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,19 +127,6 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Get Test Users
-        run: |
-          pushd services
-          export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
-          echo "TEst User 1: $TEST_USER_1"
-          export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
-          export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_3=$TEST_USER_3" >> $GITHUB_ENV
-          export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
-          echo "TEST_PASSWORD_1=$TEST_PASSWORD_1" >> $GITHUB_ENV
-          popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -150,9 +137,9 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          TEST_USER_1: ${{ env.TEST_USER_1 }}
-          TEST_USER_2: ${{ env.TEST_USER_2 }}
-          TEST_USER_3: ${{ env.TEST_USER_3 }}
+          TEST_USER_1: ${{ secrets.TEST_USER_1 }}
+          TEST_USER_2: ${{ secrets.TEST_USER_2 }}
+          TEST_USER_3: ${{ secrets.TEST_USER_3 }}
           TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
@@ -257,19 +244,6 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Get Test Users
-        run: |
-          pushd services
-          export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
-          echo "TEst User 1: $TEST_USER_1"
-          export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
-          export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_3=$TEST_USER_3" >> $GITHUB_ENV
-          export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
-          echo "TEST_PASSWORD_1=$TEST_PASSWORD_1" >> $GITHUB_ENV
-          popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -281,9 +255,9 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          TEST_USER_1: ${{ env.TEST_USER_1 }}
-          TEST_USER_2: ${{ env.TEST_USER_2 }}
-          TEST_USER_3: ${{ env.TEST_USER_3 }}
+          TEST_USER_1: ${{ secrets.TEST_USER_1 }}
+          TEST_USER_2: ${{ secrets.TEST_USER_2 }}
+          TEST_USER_3: ${{ secrets.TEST_USER_3 }}
           TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
@@ -362,19 +336,6 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Get Test Users
-        run: |
-          pushd services
-          export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
-          echo "TEst User 1: $TEST_USER_1"
-          export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
-          export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_3=$TEST_USER_3" >> $GITHUB_ENV
-          export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
-          echo "TEST_PASSWORD_1=$TEST_PASSWORD_1" >> $GITHUB_ENV
-          popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -386,9 +347,9 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          TEST_USER_1: ${{ env.TEST_USER_1 }}
-          TEST_USER_2: ${{ env.TEST_USER_2 }}
-          TEST_USER_3: ${{ env.TEST_USER_3 }}
+          TEST_USER_1: ${{ secrets.TEST_USER_1 }}
+          TEST_USER_2: ${{ secrets.TEST_USER_2 }}
+          TEST_USER_3: ${{ secrets.TEST_USER_3 }}
           TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
@@ -474,19 +435,6 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Get Test Users
-        run: |
-          pushd services
-          export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
-          echo "TEst User 1: $TEST_USER_1"
-          export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
-          export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_3=$TEST_USER_3" >> $GITHUB_ENV
-          export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
-          echo "TEST_PASSWORD_1=$TEST_PASSWORD_1" >> $GITHUB_ENV
-          popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -498,9 +446,9 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          TEST_USER_1: ${{ env.TEST_USER_1 }}
-          TEST_USER_2: ${{ env.TEST_USER_2 }}
-          TEST_USER_3: ${{ env.TEST_USER_3 }}
+          TEST_USER_1: ${{ secrets.TEST_USER_1 }}
+          TEST_USER_2: ${{ secrets.TEST_USER_2 }}
+          TEST_USER_3: ${{ secrets.TEST_USER_3 }}
           TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
@@ -607,19 +555,6 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Get Test Users
-        run: |
-          pushd services
-          export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
-          echo "TEst User 1: $TEST_USER_1"
-          export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
-          export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
-          echo "TEST_USER_3=$TEST_USER_3" >> $GITHUB_ENV
-          export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
-          echo "TEST_PASSWORD_1=$TEST_PASSWORD_1" >> $GITHUB_ENV
-          popd
       - name: Check Project A11y
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -630,7 +565,7 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          TEST_USER_1: ${{ env.TEST_USER_1 }}
-          TEST_USER_2: ${{ env.TEST_USER_2 }}
-          TEST_USER_3: ${{ env.TEST_USER_3 }}
+          TEST_USER_1: ${{ secrets.TEST_USER_1 }}
+          TEST_USER_2: ${{ secrets.TEST_USER_2 }}
+          TEST_USER_3: ${{ secrets.TEST_USER_3 }}
           TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,10 +138,10 @@ jobs:
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
           env: true
         env:
-          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-          CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
+          CYPRESS_USER_1: stateuser1@test.com
+          CYPRESS_USER_2: stateuser2@test.com
+          CYPRESS_USER_3: stateuser3@test.com
+          CYPRESS_PASSWORD_1: p@55W0rd!
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -158,419 +158,419 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  test-adult-measures:
-    name: Test Adult Measures
-    needs: deploy
-    if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val' }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        containers: [
-            AMMAD.spec.js,
-            AMRAD.spec.js,
-            BCSAD.spec.js,
-            CBPAD.spec.js,
-            CCPAD.spec.js,
-            CCSAD.spec.js,
-            CCWAD.spec.js,
-            CDFAD.spec.js,
-            CHLAD.spec.js,
-            COBAD.spec.js,
-            CPAAD.spec.js,
-            FUAAD.spec.js,
-            FUHAD.spec.js,
-            FUMAD.spec.js,
-            FVAAD.spec.js,
-            HPCAD.spec.js,
-            HPCMIAD.spec.js,
-            HVLAD.spec.js,
-            MSCAD.spec.js,
-            # NCIDDSAD.spec.js,
-            OHDAD.spec.js,
-            OUDAD.spec.js,
-            PC01AD.spec.js,
-            PCRAD.spec.js,
-            PPCAD.spec.js,
-            # PQI01AD.spec.js,
-            PQI05AD.spec.js,
-            PQI08AD.spec.js,
-            PQI15AD.spec.js,
-            QUALIFIERS_adult.spec.feature,
-            SAAAD.spec.js,
-            SSDAD.spec.js,
-          ]
-    steps:
-      - name: set branch_name
-        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - uses: actions/checkout@v1
-      - name: set branch specific variable names
-        run: ./.github/build_vars.sh set_names
-      - name: set variable values
-        run: ./.github/build_vars.sh set_values
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-          INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
-          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-          COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-      - name: Combine yarn.lock files to single file
-        run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
-      - name: cache service dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            services/app-api/node_modules
-            services/uploads/node_modules
-            services/stream-functions/node_modules
-            services/ui/node_modules
-            services/ui-auth/node_modules
-            services/ui-src/node_modules
-            node_modules
-          key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: set path
-        run: |
-          echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-      - name: Endpoint
-        run: |
-          pushd services
-          export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
-          echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
-          echo "Application endpoint: $APPLICATION_ENDPOINT"
-          popd
-      - name: Run Cypress Tests
-        uses: cypress-io/github-action@v2.11.7
-        with:
-          record: false
-          working-directory: tests/cypress
-          spec: cypress/integration/measures/${{ matrix.containers }}
-          browser: chrome
-          headless: true
-          config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
-          wait-on: ${{ env.APPLICATION_ENDPOINT }}
-          env: true
-        env:
-          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-          CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
-      - name: Upload screenshots
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: tests/cypress/screenshots/
+  # test-adult-measures:
+  #   name: Test Adult Measures
+  #   needs: deploy
+  #   if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val' }}
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       containers: [
+  #           AMMAD.spec.js,
+  #           AMRAD.spec.js,
+  #           BCSAD.spec.js,
+  #           CBPAD.spec.js,
+  #           CCPAD.spec.js,
+  #           CCSAD.spec.js,
+  #           CCWAD.spec.js,
+  #           CDFAD.spec.js,
+  #           CHLAD.spec.js,
+  #           COBAD.spec.js,
+  #           CPAAD.spec.js,
+  #           FUAAD.spec.js,
+  #           FUHAD.spec.js,
+  #           FUMAD.spec.js,
+  #           FVAAD.spec.js,
+  #           HPCAD.spec.js,
+  #           HPCMIAD.spec.js,
+  #           HVLAD.spec.js,
+  #           MSCAD.spec.js,
+  #           # NCIDDSAD.spec.js,
+  #           OHDAD.spec.js,
+  #           OUDAD.spec.js,
+  #           PC01AD.spec.js,
+  #           PCRAD.spec.js,
+  #           PPCAD.spec.js,
+  #           # PQI01AD.spec.js,
+  #           PQI05AD.spec.js,
+  #           PQI08AD.spec.js,
+  #           PQI15AD.spec.js,
+  #           QUALIFIERS_adult.spec.feature,
+  #           SAAAD.spec.js,
+  #           SSDAD.spec.js,
+  #         ]
+  #   steps:
+  #     - name: set branch_name
+  #       run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+  #     - uses: actions/checkout@v1
+  #     - name: set branch specific variable names
+  #       run: ./.github/build_vars.sh set_names
+  #     - name: set variable values
+  #       run: ./.github/build_vars.sh set_values
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+  #         INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
+  #         STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+  #         COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #     - uses: actions/setup-node@v1
+  #       with:
+  #         node-version: "12.x"
+  #     - name: Combine yarn.lock files to single file
+  #       run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
+  #     - name: cache service dependencies
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           services/app-api/node_modules
+  #           services/uploads/node_modules
+  #           services/stream-functions/node_modules
+  #           services/ui/node_modules
+  #           services/ui-auth/node_modules
+  #           services/ui-src/node_modules
+  #           node_modules
+  #         key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
+  #     - name: Install dependencies
+  #       run: yarn install --frozen-lockfile
+  #     - name: set path
+  #       run: |
+  #         echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
+  #     - name: Endpoint
+  #       run: |
+  #         pushd services
+  #         export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
+  #         echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
+  #         echo "Application endpoint: $APPLICATION_ENDPOINT"
+  #         popd
+  #     - name: Run Cypress Tests
+  #       uses: cypress-io/github-action@v2.11.7
+  #       with:
+  #         record: false
+  #         working-directory: tests/cypress
+  #         spec: cypress/integration/measures/${{ matrix.containers }}
+  #         browser: chrome
+  #         headless: true
+  #         config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
+  #         wait-on: ${{ env.APPLICATION_ENDPOINT }}
+  #         env: true
+  #       env:
+  #         CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+  #         CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+  #         CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+  #         CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
+  #     - name: Upload screenshots
+  #       uses: actions/upload-artifact@v2
+  #       if: failure()
+  #       with:
+  #         name: cypress-screenshots
+  #         path: tests/cypress/screenshots/
 
-      - name: Slack Notification
-        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,ref # selectable (default: repo,message)
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #     - name: Slack Notification
+  #       if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
+  #       uses: 8398a7/action-slack@v3
+  #       with:
+  #         status: ${{ job.status }}
+  #         fields: repo,message,commit,ref # selectable (default: repo,message)
+  #       env:
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  test-child-measures:
-    name: Test Child Measures
-    needs: setup-ch-tests
-    if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val' }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        containers:
-          [
-            AMRCH.spec.js,
-            CISCH.spec.js,
-            CPCCH.spec.js,
-            FUHCH.spec.js,
-            QUALIFIERS_child.spec.js,
-          ]
-    steps:
-      - name: set branch_name
-        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - uses: actions/checkout@v1
-      - name: set branch specific variable names
-        run: ./.github/build_vars.sh set_names
-      - name: set variable values
-        run: ./.github/build_vars.sh set_values
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-          INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
-          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-          COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-      - name: Combine yarn.lock files to single file
-        run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
-      - name: cache service dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            services/app-api/node_modules
-            services/uploads/node_modules
-            services/stream-functions/node_modules
-            services/ui/node_modules
-            services/ui-auth/node_modules
-            services/ui-src/node_modules
-            node_modules
-          key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: set path
-        run: |
-          echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-      - name: Endpoint
-        run: |
-          pushd services
-          export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
-          echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
-          echo "Application endpoint: $APPLICATION_ENDPOINT"
-          popd
-      - name: Run Cypress Tests
-        uses: cypress-io/github-action@v2.11.7
-        with:
-          record: false
-          working-directory: tests/cypress
-          spec: cypress/integration/measures/${{ matrix.containers }}
-          browser: chrome
-          headless: true
-          config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
-          wait-on: ${{ env.APPLICATION_ENDPOINT }}
-          env: true
-        env:
-          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-          CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
-      - name: Upload screenshots
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: tests/cypress/screenshots/
+  # test-child-measures:
+  #   name: Test Child Measures
+  #   needs: setup-ch-tests
+  #   if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val' }}
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       containers:
+  #         [
+  #           AMRCH.spec.js,
+  #           CISCH.spec.js,
+  #           CPCCH.spec.js,
+  #           FUHCH.spec.js,
+  #           QUALIFIERS_child.spec.js,
+  #         ]
+  #   steps:
+  #     - name: set branch_name
+  #       run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+  #     - uses: actions/checkout@v1
+  #     - name: set branch specific variable names
+  #       run: ./.github/build_vars.sh set_names
+  #     - name: set variable values
+  #       run: ./.github/build_vars.sh set_values
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+  #         INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
+  #         STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+  #         COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #     - uses: actions/setup-node@v1
+  #       with:
+  #         node-version: "12.x"
+  #     - name: Combine yarn.lock files to single file
+  #       run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
+  #     - name: cache service dependencies
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           services/app-api/node_modules
+  #           services/uploads/node_modules
+  #           services/stream-functions/node_modules
+  #           services/ui/node_modules
+  #           services/ui-auth/node_modules
+  #           services/ui-src/node_modules
+  #           node_modules
+  #         key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
+  #     - name: Install dependencies
+  #       run: yarn install --frozen-lockfile
+  #     - name: set path
+  #       run: |
+  #         echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
+  #     - name: Endpoint
+  #       run: |
+  #         pushd services
+  #         export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
+  #         echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
+  #         echo "Application endpoint: $APPLICATION_ENDPOINT"
+  #         popd
+  #     - name: Run Cypress Tests
+  #       uses: cypress-io/github-action@v2.11.7
+  #       with:
+  #         record: false
+  #         working-directory: tests/cypress
+  #         spec: cypress/integration/measures/${{ matrix.containers }}
+  #         browser: chrome
+  #         headless: true
+  #         config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
+  #         wait-on: ${{ env.APPLICATION_ENDPOINT }}
+  #         env: true
+  #       env:
+  #         CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+  #         CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+  #         CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+  #         CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
+  #     - name: Upload screenshots
+  #       uses: actions/upload-artifact@v2
+  #       if: failure()
+  #       with:
+  #         name: cypress-screenshots
+  #         path: tests/cypress/screenshots/
 
-      - name: Slack Notification
-        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,ref # selectable (default: repo,message)
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #     - name: Slack Notification
+  #       if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
+  #       uses: 8398a7/action-slack@v3
+  #       with:
+  #         status: ${{ job.status }}
+  #         fields: repo,message,commit,ref # selectable (default: repo,message)
+  #       env:
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  test-features:
-    name: Test Features
-    needs: test-adult-measures
-    if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val'}}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        containers:
-          [
-            add_validation_to_rate_when_user_selects_multiple_Data_Sources.spec.js,
-            adding_link_to_combined_rates_component.spec.js,
-            data_source_rate_to_auto_calculate_in_OPM.spec.js,
-            combined_rates_validation_warnings.spec.js,
-            date_range_adjustment.spec.js,
-            FAQ.spec.js,
-            logo.spec.feature,
-            measure_validation_error_creation_updates.spec.feature,
-            NDR_validation_updates.spec.js,
-            reporting_in_FY21_tag_for_alt_data_sources.spec.js,
-            restructuring_data_source_text_boxes.spec.js,
-            update_user_auth_handling_in_ui.spec.feature,
-          ]
-    steps:
-      - name: set branch_name
-        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - uses: actions/checkout@v1
-      - name: set branch specific variable names
-        run: ./.github/build_vars.sh set_names
-      - name: set variable values
-        run: ./.github/build_vars.sh set_values
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-          INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
-          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-          COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-      - name: Combine yarn.lock files to single file
-        run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
-      - name: cache service dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            services/app-api/node_modules
-            services/uploads/node_modules
-            services/stream-functions/node_modules
-            services/ui/node_modules
-            services/ui-auth/node_modules
-            services/ui-src/node_modules
-            node_modules
-          key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: set path
-        run: |
-          echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-      - name: Endpoint
-        run: |
-          pushd services
-          export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
-          echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
-          echo "Application endpoint: $APPLICATION_ENDPOINT"
-          popd
-      - name: Run Cypress Tests
-        uses: cypress-io/github-action@v2.11.7
-        with:
-          record: false
-          working-directory: tests/cypress
-          spec: cypress/integration/features/${{ matrix.containers }}
-          browser: chrome
-          headless: true
-          config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
-          wait-on: ${{ env.APPLICATION_ENDPOINT }}
-          env: true
-        env:
-          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-          CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
-      - name: Upload screenshots
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: tests/cypress/screenshots/
+  # test-features:
+  #   name: Test Features
+  #   needs: test-adult-measures
+  #   if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val'}}
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       containers:
+  #         [
+  #           add_validation_to_rate_when_user_selects_multiple_Data_Sources.spec.js,
+  #           adding_link_to_combined_rates_component.spec.js,
+  #           data_source_rate_to_auto_calculate_in_OPM.spec.js,
+  #           combined_rates_validation_warnings.spec.js,
+  #           date_range_adjustment.spec.js,
+  #           FAQ.spec.js,
+  #           logo.spec.feature,
+  #           measure_validation_error_creation_updates.spec.feature,
+  #           NDR_validation_updates.spec.js,
+  #           reporting_in_FY21_tag_for_alt_data_sources.spec.js,
+  #           restructuring_data_source_text_boxes.spec.js,
+  #           update_user_auth_handling_in_ui.spec.feature,
+  #         ]
+  #   steps:
+  #     - name: set branch_name
+  #       run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+  #     - uses: actions/checkout@v1
+  #     - name: set branch specific variable names
+  #       run: ./.github/build_vars.sh set_names
+  #     - name: set variable values
+  #       run: ./.github/build_vars.sh set_values
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+  #         INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
+  #         STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+  #         COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #     - uses: actions/setup-node@v1
+  #       with:
+  #         node-version: "12.x"
+  #     - name: Combine yarn.lock files to single file
+  #       run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
+  #     - name: cache service dependencies
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           services/app-api/node_modules
+  #           services/uploads/node_modules
+  #           services/stream-functions/node_modules
+  #           services/ui/node_modules
+  #           services/ui-auth/node_modules
+  #           services/ui-src/node_modules
+  #           node_modules
+  #         key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
+  #     - name: Install dependencies
+  #       run: yarn install --frozen-lockfile
+  #     - name: set path
+  #       run: |
+  #         echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
+  #     - name: Endpoint
+  #       run: |
+  #         pushd services
+  #         export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
+  #         echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
+  #         echo "Application endpoint: $APPLICATION_ENDPOINT"
+  #         popd
+  #     - name: Run Cypress Tests
+  #       uses: cypress-io/github-action@v2.11.7
+  #       with:
+  #         record: false
+  #         working-directory: tests/cypress
+  #         spec: cypress/integration/features/${{ matrix.containers }}
+  #         browser: chrome
+  #         headless: true
+  #         config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
+  #         wait-on: ${{ env.APPLICATION_ENDPOINT }}
+  #         env: true
+  #       env:
+  #         CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+  #         CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+  #         CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+  #         CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
+  #     - name: Upload screenshots
+  #       uses: actions/upload-artifact@v2
+  #       if: failure()
+  #       with:
+  #         name: cypress-screenshots
+  #         path: tests/cypress/screenshots/
 
-      - name: Slack Notification
-        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,ref # selectable (default: repo,message)
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #     - name: Slack Notification
+  #       if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["master", "val", "prod"]'), env.branch_name) && failure ()
+  #       uses: 8398a7/action-slack@v3
+  #       with:
+  #         status: ${{ job.status }}
+  #         fields: repo,message,commit,ref # selectable (default: repo,message)
+  #       env:
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  a11y-tests:
-    name: Test Ally
-    needs: [test-adult-measures, test-child-measures]
-    if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val' }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        containers: [
-            ammadPage,
-            # amradPage,
-            # bcsadPage,
-            # cbpadPage,
-            # ccpadPage,
-            # ccsadPage,
-            # ccwadPage,
-            # cdfadPage,
-            # chladPage,
-            # cobadPage,
-            # commonPages,
-            # cpaadPage,
-            # faqPage,
-            # fuadPage,
-            # fuhadPage,
-            # fumadPage,
-            # fvaadPage,
-            # hpcadPage,
-            # hpcmiadPage,
-            # hvladPage,
-            # ietadPage,
-            # mscadPage,
-            # nciddsPage,
-            # ohdadPage,
-            # oudadPage,
-            # pc01adPage,
-            # pcradPage,
-            # ppcadPage,
-            # pqi01adPage,
-            # pqi05adPage,
-            # pqi08adPage,
-            # pqi15adPage,
-            # ssaadPage,
-            # ssdadPage,
-          ]
-    steps:
-      - name: set branch_name
-        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - uses: actions/checkout@v1
-      - name: set branch specific variable names
-        run: ./.github/build_vars.sh set_names
-      - name: set variable values
-        run: ./.github/build_vars.sh set_values
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-          INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
-          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-          COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-      - name: Combine yarn.lock files to single file
-        run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
-      - name: cache service dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            services/app-api/node_modules
-            services/uploads/node_modules
-            services/stream-functions/node_modules
-            services/ui/node_modules
-            services/ui-auth/node_modules
-            services/ui-src/node_modules
-            node_modules
-          key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: set path
-        run: |
-          echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-      - name: Endpoint
-        run: |
-          pushd services
-          export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
-          echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
-          echo "Application endpoint: $APPLICATION_ENDPOINT"
-          popd
-      - name: Check Project A11y
-        uses: cypress-io/github-action@v2.11.7
-        with:
-          working-directory: tests/cypress
-          spec: cypress/integration/a11y/${{ matrix.containers }}.spec.js
-          browser: chrome
-          headless: true
-          config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
-          wait-on: ${{ env.APPLICATION_ENDPOINT }}
-          env: true
-        env:
-          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-          CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}
+  # a11y-tests:
+  #   name: Test Ally
+  #   needs: [test-adult-measures, test-child-measures]
+  #   if: ${{ github.ref != 'refs/heads/prod' && github.ref != 'refs/heads/val' }}
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       containers: [
+  #           ammadPage,
+  #           # amradPage,
+  #           # bcsadPage,
+  #           # cbpadPage,
+  #           # ccpadPage,
+  #           # ccsadPage,
+  #           # ccwadPage,
+  #           # cdfadPage,
+  #           # chladPage,
+  #           # cobadPage,
+  #           # commonPages,
+  #           # cpaadPage,
+  #           # faqPage,
+  #           # fuadPage,
+  #           # fuhadPage,
+  #           # fumadPage,
+  #           # fvaadPage,
+  #           # hpcadPage,
+  #           # hpcmiadPage,
+  #           # hvladPage,
+  #           # ietadPage,
+  #           # mscadPage,
+  #           # nciddsPage,
+  #           # ohdadPage,
+  #           # oudadPage,
+  #           # pc01adPage,
+  #           # pcradPage,
+  #           # ppcadPage,
+  #           # pqi01adPage,
+  #           # pqi05adPage,
+  #           # pqi08adPage,
+  #           # pqi15adPage,
+  #           # ssaadPage,
+  #           # ssdadPage,
+  #         ]
+  #   steps:
+  #     - name: set branch_name
+  #       run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+  #     - uses: actions/checkout@v1
+  #     - name: set branch specific variable names
+  #       run: ./.github/build_vars.sh set_names
+  #     - name: set variable values
+  #       run: ./.github/build_vars.sh set_values
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+  #         INFRASTRUCTURE_TYPE: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_INFRASTRUCTURE_TYPE] || secrets.INFRASTRUCTURE_TYPE || 'development' }}
+  #         STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+  #         COGNITO_TEST_USERS_PASSWORD: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_COGNITO_TEST_USERS_PASSWORD] || secrets.COGNITO_TEST_USERS_PASSWORD }}
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #     - uses: actions/setup-node@v1
+  #       with:
+  #         node-version: "12.x"
+  #     - name: Combine yarn.lock files to single file
+  #       run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn.txt
+  #     - name: cache service dependencies
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: |
+  #           services/app-api/node_modules
+  #           services/uploads/node_modules
+  #           services/stream-functions/node_modules
+  #           services/ui/node_modules
+  #           services/ui-auth/node_modules
+  #           services/ui-src/node_modules
+  #           node_modules
+  #         key: ${{ runner.os }}-${{ hashFiles('combined-yarn.txt') }}
+  #     - name: Install dependencies
+  #       run: yarn install --frozen-lockfile
+  #     - name: set path
+  #       run: |
+  #         echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
+  #     - name: Endpoint
+  #       run: |
+  #         pushd services
+  #         export APPLICATION_ENDPOINT=`./output.sh ui ApplicationEndpointUrl $STAGE_PREFIX$branch_name`
+  #         echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
+  #         echo "Application endpoint: $APPLICATION_ENDPOINT"
+  #         popd
+  #     - name: Check Project A11y
+  #       uses: cypress-io/github-action@v2.11.7
+  #       with:
+  #         working-directory: tests/cypress
+  #         spec: cypress/integration/a11y/${{ matrix.containers }}.spec.js
+  #         browser: chrome
+  #         headless: true
+  #         config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
+  #         wait-on: ${{ env.APPLICATION_ENDPOINT }}
+  #         env: true
+  #       env:
+  #         CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+  #         CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+  #         CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+  #         CYPRESS_PASSWORD_1: ${{ secrets.CYPRESS_PASSWORD_1 }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,9 +131,13 @@ jobs:
         run: |
           pushd services
           export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
           export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
           export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_3=$TEST_USER_3" >> $GITHUB_ENV
           export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
+          echo "TEST_PASSWORD_1=$TEST_PASSWORD_1" >> $GITHUB_ENV
           popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
@@ -256,9 +260,14 @@ jobs:
         run: |
           pushd services
           export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
           export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
           export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_3=$TEST_USER_3" >> $GITHUB_ENV
           export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
+          echo "TEST_PASSWORD_1=$TEST_PASSWORD_1" >> $GITHUB_ENV
+          popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -355,9 +364,13 @@ jobs:
         run: |
           pushd services
           export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
           export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
           export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_3=$TEST_USER_3" >> $GITHUB_ENV
           export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
+          echo "TEST_PASSWORD_1=$TEST_PASSWORD_1" >> $GITHUB_ENV
           popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
@@ -462,9 +475,13 @@ jobs:
         run: |
           pushd services
           export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
           export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
           export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_3=$TEST_USER_3" >> $GITHUB_ENV
           export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
+          echo "TEST_PASSWORD_1=$TEST_PASSWORD_1" >> $GITHUB_ENV
           popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
@@ -590,9 +607,13 @@ jobs:
         run: |
           pushd services
           export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_1=$TEST_USER_1" >> $GITHUB_ENV
           export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_=2$TEST_USER_2" >> $GITHUB_ENV
           export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
+          echo "TEST_USER_3=$TEST_USER_3" >> $GITHUB_ENV
           export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
+          echo "TEST_PASSWORD_1=$TEST_PASSWORD_1" >> $GITHUB_ENV
           popd
       - name: Check Project A11y
         uses: cypress-io/github-action@v2.11.7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,6 +127,14 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
+      - name: Get Test Users
+        run: |
+          pushd services
+          export CYPRESS_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
+          export CYPRESS_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
+          export CYPRESS_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
+          export CYPRESS_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
+          popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -137,11 +145,16 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
           env: true
-        env:
-          CYPRESS_USER_1: stateuser1@test.com
-          CYPRESS_USER_2: stateuser2@test.com
-          CYPRESS_USER_3: stateuser3@test.com
-          CYPRESS_PASSWORD_1: p@55W0rd!
+        # env:
+        #   CYPRESS_USER_1: ${{ env.CYPRESS_USER_1 }}
+        #   CYPRESS_USER_2: ${{ env.CYPRESS_USER_2 }}
+        #   CYPRESS_USER_3: ${{ env.CYPRESS_USER_3 }}
+        #   CYPRESS_PASSWORD_1: ${{ env.CYPRESS_PASSWORD_1 }}
+        # env:
+        #   CYPRESS_USER_1: stateuser1@test.com
+        #   CYPRESS_USER_2: stateuser2@test.com
+        #   CYPRESS_USER_3: stateuser3@test.com
+        #   CYPRESS_PASSWORD_1: p@55W0rd!
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,11 +127,11 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Make Test Config
-        run: |
-          pushd tests/cypress
-          sh configureLocal.sh $branch_name
-          popd
+      # - name: Make Test Config
+      #   run: |
+      #     pushd tests/cypress
+      #     sh configureLocal.sh $branch_name
+      #     popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -141,6 +141,12 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
+        env:
+          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+          CYPRESS_USER_PW: ${{ secrets.CYPRESS_USER_PW }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -244,11 +250,11 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Make Test Config
-        run: |
-          pushd tests/cypress
-          sh configureLocal.sh $branch_name
-          popd
+      # - name: Make Test Config
+      #   run: |
+      #     pushd tests/cypress
+      #     sh configureLocal.sh $branch_name
+      #     popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -259,6 +265,12 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
+        env:
+          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+          CYPRESS_USER_PW: ${{ secrets.CYPRESS_USER_PW }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -336,11 +348,11 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Make Test Config
-        run: |
-          pushd tests/cypress
-          sh configureLocal.sh $branch_name
-          popd
+      # - name: Make Test Config
+      #   run: |
+      #     pushd tests/cypress
+      #     sh configureLocal.sh $branch_name
+      #     popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -351,6 +363,12 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
+        env:
+          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+          CYPRESS_USER_PW: ${{ secrets.CYPRESS_USER_PW }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -435,11 +453,11 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Make Test Config
-        run: |
-          pushd tests/cypress
-          sh configureLocal.sh $branch_name
-          popd
+      # - name: Make Test Config
+      #   run: |
+      #     pushd tests/cypress
+      #     sh configureLocal.sh $branch_name
+      #     popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -450,6 +468,12 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
+        env:
+          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+          CYPRESS_USER_PW: ${{ secrets.CYPRESS_USER_PW }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -555,11 +579,11 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Make Test Config
-        run: |
-          pushd tests/cypress
-          sh configureLocal.sh $branch_name
-          popd
+      # - name: Make Test Config
+      #   run: |
+      #     pushd tests/cypress
+      #     sh configureLocal.sh $branch_name
+      #     popd
       - name: Check Project A11y
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -569,5 +593,11 @@ jobs:
           headless: true
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
+          env: true
+        env:
+          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
+          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
+          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
+          CYPRESS_USER_PW: ${{ secrets.CYPRESS_USER_PW }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,36 +72,6 @@ jobs:
           # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
           # This can optionally be set as an GitHub Actions Secret
           ./deploy.sh $STAGE_PREFIX$branch_name
-  set-env:
-    runs-on: ubuntu-latest
-    needs: deploy
-    steps:
-      - name: set branch_name
-        run: |
-          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
-            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
-          else
-            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-          fi
-      - uses: actions/checkout@v2
-      - name: Validate branch name
-        run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
-      - name: set branch specific variable names
-        run: ./.github/build_vars.sh set_names
-      - name: set variable values
-        run: ./.github/build_vars.sh set_values
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
-      - name: Make Test Config
-        run: |
-          pushd tests/cypress
-          sh configureLocal.sh $branch_name
-          popd
 
   setup-ch-tests:
     name: Init Child
@@ -157,10 +127,13 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Make Test Config
+      - name: Get Test Users
         run: |
-          pushd tests/cypress
-          sh configureLocal.sh $branch_name
+          pushd services
+          export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
+          export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
+          export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
+          export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
           popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
@@ -172,10 +145,10 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-          CYPRESS_USER_PW: ${{ secrets.CYPRESS_USER_PW }}
+          TEST_USER_1: ${{ env.TEST_USER_1 }}
+          TEST_USER_2: ${{ env.TEST_USER_2 }}
+          TEST_USER_3: ${{ env.TEST_USER_3 }}
+          TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -279,11 +252,13 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Make Test Config
+      - name: Get Test Users
         run: |
-          pushd tests/cypress
-          sh configureLocal.sh $branch_name
-          popd
+          pushd services
+          export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
+          export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
+          export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
+          export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
         with:
@@ -295,10 +270,10 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-          CYPRESS_USER_PW: ${{ secrets.CYPRESS_USER_PW }}
+          TEST_USER_1: ${{ env.TEST_USER_1 }}
+          TEST_USER_2: ${{ env.TEST_USER_2 }}
+          TEST_USER_3: ${{ env.TEST_USER_3 }}
+          TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -376,10 +351,13 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Make Test Config
+      - name: Get Test Users
         run: |
-          pushd tests/cypress
-          sh configureLocal.sh $branch_name
+          pushd services
+          export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
+          export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
+          export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
+          export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
           popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
@@ -392,10 +370,10 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-          CYPRESS_USER_PW: ${{ secrets.CYPRESS_USER_PW }}
+          TEST_USER_1: ${{ env.TEST_USER_1 }}
+          TEST_USER_2: ${{ env.TEST_USER_2 }}
+          TEST_USER_3: ${{ env.TEST_USER_3 }}
+          TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -480,10 +458,13 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Make Test Config
+      - name: Get Test Users
         run: |
-          pushd tests/cypress
-          sh configureLocal.sh $branch_name
+          pushd services
+          export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
+          export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
+          export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
+          export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
           popd
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2.11.7
@@ -496,10 +477,10 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-          CYPRESS_USER_PW: ${{ secrets.CYPRESS_USER_PW }}
+          TEST_USER_1: ${{ env.TEST_USER_1 }}
+          TEST_USER_2: ${{ env.TEST_USER_2 }}
+          TEST_USER_3: ${{ env.TEST_USER_3 }}
+          TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()
@@ -605,10 +586,13 @@ jobs:
           echo "APPLICATION_ENDPOINT=$APPLICATION_ENDPOINT" >> $GITHUB_ENV
           echo "Application endpoint: $APPLICATION_ENDPOINT"
           popd
-      - name: Make Test Config
+      - name: Get Test Users
         run: |
-          pushd tests/cypress
-          sh configureLocal.sh $branch_name
+          pushd services
+          export TEST_USER_1=`./output.sh ui TestUserOne $STAGE_PREFIX$branch_name`
+          export TEST_USER_2=`./output.sh ui TestUserTwo $STAGE_PREFIX$branch_name`
+          export TEST_USER_3=`./output.sh ui TestUserThree $STAGE_PREFIX$branch_name`
+          export TEST_PASSWORD_1=`./output.sh ui TestPasswordOne $STAGE_PREFIX$branch_name`
           popd
       - name: Check Project A11y
         uses: cypress-io/github-action@v2.11.7
@@ -620,7 +604,7 @@ jobs:
           config: baseUrl=${{ env.APPLICATION_ENDPOINT }}
           wait-on: ${{ env.APPLICATION_ENDPOINT }}
         env:
-          CYPRESS_USER_1: ${{ secrets.CYPRESS_USER_1 }}
-          CYPRESS_USER_2: ${{ secrets.CYPRESS_USER_2 }}
-          CYPRESS_USER_3: ${{ secrets.CYPRESS_USER_3 }}
-          CYPRESS_USER_PW: ${{ secrets.CYPRESS_USER_PW }}
+          TEST_USER_1: ${{ env.TEST_USER_1 }}
+          TEST_USER_2: ${{ env.TEST_USER_2 }}
+          TEST_USER_3: ${{ env.TEST_USER_3 }}
+          TEST_PASSWORD_1: ${{ env.TEST_PASSWORD_1 }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,39 +8,8 @@ on:
       - "!skipci*"
 
 jobs:
-  set-env:
-    runs-on: ubuntu-latest
-    steps:
-      - name: set branch_name
-        run: |
-          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
-            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
-          else
-            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-          fi
-      - uses: actions/checkout@v2
-      - name: Validate branch name
-        run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
-      - name: set branch specific variable names
-        run: ./.github/build_vars.sh set_names
-      - name: set variable values
-        run: ./.github/build_vars.sh set_values
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
-          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
-      - name: Make Test Config
-        run: |
-          pushd tests/cypress
-          sh configureLocal.sh $branch_name
-          popd
-
   deploy:
     runs-on: ubuntu-latest
-    needs: set-env
     env:
       SLS_DEPRECATION_DISABLE: "*" # Turn off deprecation warnings in the pipeline
     steps:
@@ -103,6 +72,36 @@ jobs:
           # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
           # This can optionally be set as an GitHub Actions Secret
           ./deploy.sh $STAGE_PREFIX$branch_name
+  set-env:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: set branch_name
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
+            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
+          else
+            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          fi
+      - uses: actions/checkout@v2
+      - name: Validate branch name
+        run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
+      - name: set branch specific variable names
+        run: ./.github/build_vars.sh set_names
+      - name: set variable values
+        run: ./.github/build_vars.sh set_values
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
+      - name: Make Test Config
+        run: |
+          pushd tests/cypress
+          sh configureLocal.sh $branch_name
+          popd
 
   setup-ch-tests:
     name: Init Child

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,20 @@ jobs:
           else
             echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           fi
+      - uses: actions/checkout@v2
       - name: Validate branch name
         run: ./.github/branchNameValidation.sh $STAGE_PREFIX$branch_name
+      - name: set branch specific variable names
+        run: ./.github/build_vars.sh set_names
+      - name: set variable values
+        run: ./.github/build_vars.sh set_values
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_ACCESS_KEY_ID] || secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_SECRET_ACCESS_KEY] || secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
+          STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
       - name: Make Test Config
         run: |
           pushd tests/cypress

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ tests/cypress/screenshots
 tests/cypress/package-lock.json
 package-lock.json
 tests/cypress/.env
-tests/cypress/test-config.js
+tests/cypress/cypress.env.json

--- a/README.md
+++ b/README.md
@@ -122,14 +122,14 @@ When the tests have been written, create a new PR for `oy2-1234test` and set its
 
 ## Dependencies
 
-In order to hide the crendentials of test users a shell script has been added to the tests/cypress directory which is used to generate a test-config.js file used to login with the test users. It is run in the following manner:
+In order to hide the crendentials of test users a shell script has been added to the tests/cypress directory which is used to generate a cypress.env.json file used to login with the test users. It is run in the following manner:
 
 (Add your AWS Access tokens)
 (Run this in the tests/cypress directory)
 
 sh configureLocal.sh your-branch-name
 
-Once it is done runnning you should see a test-config.js file in your tests/cypress directory and now the tests will be able to properly access the right credentials.
+Once it is done runnning you should see a cypress.env.json file in your tests/cypress directory and now the tests will be able to properly access the right credentials.
 
 ## Examples
 

--- a/tests/cypress/configureLocal.sh
+++ b/tests/cypress/configureLocal.sh
@@ -27,8 +27,8 @@ export TEST_PASSWORD_1=$test_password_1
 rm -rf ./cypress.env.json
 touch ./cypress.env.json
 echo "{" >> ./cypress.env.json
-echo "\"CYPRESS_USER_1\": \"$test_user_1\"," >> ./cypress.env.json
-echo "\"CYPRESS_USER_2\": \"$test_user_2\"," >> ./cypress.env.json
-echo "\"CYPRESS_USER_3\": \"$test_user_3\"," >> ./cypress.env.json
-echo "\"CYPRESS_PASSWORD_1\": \"$test_password_1\"" >> ./cypress.env.json
+echo "\"TEST_USER_1\": \"$test_user_1\"," >> ./cypress.env.json
+echo "\"TEST_USER_2\": \"$test_user_2\"," >> ./cypress.env.json
+echo "\"TEST_USER_3\": \"$test_user_3\"," >> ./cypress.env.json
+echo "\"TEST_PASSWORD_1\": \"$test_password_1\"" >> ./cypress.env.json
 echo "}" >> ./cypress.env.json

--- a/tests/cypress/configureLocal.sh
+++ b/tests/cypress/configureLocal.sh
@@ -29,12 +29,11 @@ echo $test_user_2
 echo $test_user_3
 echo $test_password_1
 
-rm -rf ./test-config.js
-touch ./test-config.js
-echo "const testConfig = {" >> ./test-config.js
-echo "TEST_USER_1: \"$test_user_1\"," >> ./test-config.js
-echo "TEST_USER_2: \"$test_user_2\"," >> ./test-config.js
-echo "TEST_USER_3: \"$test_user_3\"," >> ./test-config.js
-echo "TEST_PASSWORD_1: \"$test_password_1\"," >> ./test-config.js
-echo "}" >> ./test-config.js
-echo "export default testConfig;" >> ./test-config.js
+rm -rf ./cypress.env.json
+touch ./cypress.env.json
+echo "{" >> ./cypress.env.json
+echo "\"TEST_USER_1\": \"$test_user_1\"," >> ./cypress.env.json
+echo "\"TEST_USER_2\": \"$test_user_2\"," >> ./cypress.env.json
+echo "\"TEST_USER_3\": \"$test_user_3\"," >> ./cypress.env.json
+echo "\"TEST_PASSWORD_1\": \"$test_password_1\"" >> ./cypress.env.json
+echo "}" >> ./cypress.env.json

--- a/tests/cypress/configureLocal.sh
+++ b/tests/cypress/configureLocal.sh
@@ -24,16 +24,11 @@ export TEST_USER_2=$test_user_2
 export TEST_USER_3=$test_user_3
 export TEST_PASSWORD_1=$test_password_1
 
-echo $test_user_1
-echo $test_user_2
-echo $test_user_3
-echo $test_password_1
-
 rm -rf ./cypress.env.json
 touch ./cypress.env.json
 echo "{" >> ./cypress.env.json
-echo "\"TEST_USER_1\": \"$test_user_1\"," >> ./cypress.env.json
-echo "\"TEST_USER_2\": \"$test_user_2\"," >> ./cypress.env.json
-echo "\"TEST_USER_3\": \"$test_user_3\"," >> ./cypress.env.json
-echo "\"TEST_PASSWORD_1\": \"$test_password_1\"" >> ./cypress.env.json
+echo "\"CYPRESS_USER_1\": \"$test_user_1\"," >> ./cypress.env.json
+echo "\"CYPRESS_USER_2\": \"$test_user_2\"," >> ./cypress.env.json
+echo "\"CYPRESS_USER_3\": \"$test_user_3\"," >> ./cypress.env.json
+echo "\"CYPRESS_PASSWORD_1\": \"$test_password_1\"" >> ./cypress.env.json
 echo "}" >> ./cypress.env.json

--- a/tests/cypress/configureLocal.sh
+++ b/tests/cypress/configureLocal.sh
@@ -24,6 +24,11 @@ export TEST_USER_2=$test_user_2
 export TEST_USER_3=$test_user_3
 export TEST_PASSWORD_1=$test_password_1
 
+echo $test_user_1
+echo $test_user_2
+echo $test_user_3
+echo $test_password_1
+
 rm -rf ./test-config.js
 touch ./test-config.js
 echo "const testConfig = {" >> ./test-config.js

--- a/tests/cypress/cypress.json
+++ b/tests/cypress/cypress.json
@@ -13,11 +13,5 @@
   "downloadsFolder": "downloads",
   "supportFile": "support/index.js",
   "defaultCommandTimeout": 15000,
-  "types": ["cypress", "cypress-axe"],
-  "env": {
-    "USER_1": "",
-    "USER_2": "",
-    "USER_3": "",
-    "PASSWORD_1": ""
-  }
+  "types": ["cypress", "cypress-axe"]
 }

--- a/tests/cypress/cypress.json
+++ b/tests/cypress/cypress.json
@@ -13,5 +13,11 @@
   "downloadsFolder": "downloads",
   "supportFile": "support/index.js",
   "defaultCommandTimeout": 15000,
-  "types": ["cypress", "cypress-axe"]
+  "types": ["cypress", "cypress-axe"],
+  "env": {
+    "USER_1": "",
+    "USER_2": "",
+    "USER_3": "",
+    "PASSWORD_1": ""
+  }
 }

--- a/tests/cypress/support/commands/commands.js
+++ b/tests/cypress/support/commands/commands.js
@@ -31,12 +31,10 @@ Cypress.Commands.add(
       stateuser3: require("../../test-config.js")["TEST_USER_3"],
       stateuser2: require("../../test-config.js")["TEST_USER_2"],
     };
-    cy.wait(3000);
     cy.visit("/");
-    cy.wait(3000);
-    cy.xpath(emailForCognito).type(`${users[user]}`);
+    cy.xpath(emailForCognito).type(`${users[user]}` || "stateuser3@test.com");
     cy.xpath(passwordForCognito).type(
-      require("../../test-config.js")["TEST_PASSWORD_1"]
+      require("../../test-config.js")["TEST_PASSWORD_1"] || "p@55W0rd!"
     );
     cy.get('[data-cy="login-with-cognito-button"]').click();
   }

--- a/tests/cypress/support/commands/commands.js
+++ b/tests/cypress/support/commands/commands.js
@@ -1,6 +1,5 @@
 import "cypress-file-upload";
 import "cypress-wait-until";
-import testConfig from "../../test-config.js";
 import "cypress-file-upload";
 // allow for Cypress Snapshot command
 import { addMatchImageSnapshotCommand } from "cypress-image-snapshot/command";
@@ -27,14 +26,12 @@ Cypress.Commands.add(
     user = "stateuser3" // pragma: allowlist secret
   ) => {
     const users = {
-      stateuser3: Cypress.env("CYPRESS_USER_3") || testConfig.TEST_USER_3,
-      stateuser2: Cypress.env("CYPRESS_USER_2") || testConfig.TEST_USER_2,
+      stateuser3: Cypress.env("TEST_USER_3"),
+      stateuser2: Cypress.env("TEST_USER_2"),
     };
     cy.visit("/");
     cy.xpath(emailForCognito).type(`${users[user]}`);
-    cy.xpath(passwordForCognito).type(
-      Cypress.env("CYPRESS_USER_PW") || testConfig.TEST_PASSWORD_1
-    );
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
     cy.get('[data-cy="login-with-cognito-button"]').click();
   }
 );

--- a/tests/cypress/support/commands/commands.js
+++ b/tests/cypress/support/commands/commands.js
@@ -26,12 +26,12 @@ Cypress.Commands.add(
     user = "stateuser3" // pragma: allowlist secret
   ) => {
     const users = {
-      stateuser3: Cypress.env("CYPRESS_USER_3"),
-      stateuser2: Cypress.env("CYPRESS_USER_2"),
+      stateuser3: Cypress.env("USER_3"),
+      stateuser2: Cypress.env("USER_2"),
     };
     cy.visit("/");
     cy.xpath(emailForCognito).type(`${users[user]}`);
-    cy.xpath(passwordForCognito).type(Cypress.env("CYPRESS_PASSWORD_1"));
+    cy.xpath(passwordForCognito).type(Cypress.env("PASSWORD_1"));
     cy.get('[data-cy="login-with-cognito-button"]').click();
   }
 );

--- a/tests/cypress/support/commands/commands.js
+++ b/tests/cypress/support/commands/commands.js
@@ -26,12 +26,12 @@ Cypress.Commands.add(
     user = "stateuser3" // pragma: allowlist secret
   ) => {
     const users = {
-      stateuser3: Cypress.env("TEST_USER_3"),
-      stateuser2: Cypress.env("TEST_USER_2"),
+      stateuser3: Cypress.env("CYPRESS_USER_3"),
+      stateuser2: Cypress.env("CYPRESS_USER_2"),
     };
     cy.visit("/");
     cy.xpath(emailForCognito).type(`${users[user]}`);
-    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
+    cy.xpath(passwordForCognito).type(Cypress.env("CYPRESS_PASSWORD_1"));
     cy.get('[data-cy="login-with-cognito-button"]').click();
   }
 );

--- a/tests/cypress/support/commands/commands.js
+++ b/tests/cypress/support/commands/commands.js
@@ -26,12 +26,12 @@ Cypress.Commands.add(
     user = "stateuser3" // pragma: allowlist secret
   ) => {
     const users = {
-      stateuser3: Cypress.env("USER_3"),
-      stateuser2: Cypress.env("USER_2"),
+      stateuser3: Cypress.env("TEST_USER_3"),
+      stateuser2: Cypress.env("TEST_USER_2"),
     };
     cy.visit("/");
     cy.xpath(emailForCognito).type(`${users[user]}`);
-    cy.xpath(passwordForCognito).type(Cypress.env("PASSWORD_1"));
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
     cy.get('[data-cy="login-with-cognito-button"]').click();
   }
 );

--- a/tests/cypress/support/commands/commands.js
+++ b/tests/cypress/support/commands/commands.js
@@ -1,12 +1,11 @@
 import "cypress-file-upload";
 import "cypress-wait-until";
-// import testConfig from "../../test-config.js";
+import testConfig from "../../test-config.js";
 import "cypress-file-upload";
 // allow for Cypress Snapshot command
 import { addMatchImageSnapshotCommand } from "cypress-image-snapshot/command";
 
 before(() => {
-  cy.wait(15000);
   cy.visit("/", { timeout: 60000 * 7 });
 });
 
@@ -28,13 +27,13 @@ Cypress.Commands.add(
     user = "stateuser3" // pragma: allowlist secret
   ) => {
     const users = {
-      stateuser3: require("../../test-config.js")["TEST_USER_3"],
-      stateuser2: require("../../test-config.js")["TEST_USER_2"],
+      stateuser3: Cypress.env("CYPRESS_USER_3") || testConfig.TEST_USER_3,
+      stateuser2: Cypress.env("CYPRESS_USER_2") || testConfig.TEST_USER_2,
     };
     cy.visit("/");
-    cy.xpath(emailForCognito).type(`${users[user]}` || "stateuser3@test.com");
+    cy.xpath(emailForCognito).type(`${users[user]}`);
     cy.xpath(passwordForCognito).type(
-      require("../../test-config.js")["TEST_PASSWORD_1"] || "p@55W0rd!"
+      Cypress.env("CYPRESS_USER_PW") || testConfig.TEST_PASSWORD_1
     );
     cy.get('[data-cy="login-with-cognito-button"]').click();
   }

--- a/tests/cypress/support/pages/LoginPage.js
+++ b/tests/cypress/support/pages/LoginPage.js
@@ -1,4 +1,3 @@
-import testConfig from "../../test-config.js";
 const usernameInput = "input#okta-signin-username";
 const emailForCognito = "//input[@name='email']";
 const passwordForCognito = "//input[@name='password']";
@@ -11,15 +10,15 @@ const goToStateHomeBTN = "//button[contains(text(),'Go To State Home')]";
 export class LoginPage {
   enterUserName() {
     //cy.get(usernameInput).type("State_QMR2");
-    cy.get(usernameInput).type(testConfig.TEST_USER_3);
+    cy.get(usernameInput).type(Cypress.env("TEST_USER_3"));
   }
 
   enterEmailwithCognitoLogin() {
-    cy.xpath(emailForCognito).type(testConfig.TEST_USER_3);
+    cy.xpath(emailForCognito).type(Cypress.env("TEST_USER_3"));
   }
 
   enterPasswordwithCognitoLogin() {
-    cy.xpath(passwordForCognito).type(testConfig.TEST_PASSWORD_1);
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
   }
 
   clickLoginWithCognitoButtn() {
@@ -27,11 +26,11 @@ export class LoginPage {
   }
 
   enterEmailwithCognitoLogin() {
-    cy.xpath(emailForCognito).type(testConfig.TEST_USER_2);
+    cy.xpath(emailForCognito).type(Cypress.env("TEST_USER_2"));
   }
 
   enterPasswordwithCognitoLogin() {
-    cy.xpath(passwordForCognito).type(testConfig.TEST_PASSWORD_1);
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
   }
 
   clickLoginWithCognitoButtn() {
@@ -39,7 +38,7 @@ export class LoginPage {
   }
 
   enterPassword() {
-    cy.get(passwordInput).type(testConfig.TEST_PASSWORD_1);
+    cy.get(passwordInput).type(Cypress.env("TEST_PASSWORD_1"));
   }
 
   //old credentials
@@ -55,27 +54,27 @@ export class LoginPage {
   }
 
   loginasAStateUser() {
-    cy.get(usernameInput).type(testConfig.TEST_USER_2);
-    cy.get(passwordInput).type(testConfig.TEST_PASSWORD_1);
+    cy.get(usernameInput).type(Cypress.env("TEST_USER_2"));
+    cy.get(passwordInput).type(Cypress.env("TEST_PASSWORD_1"));
     cy.get(agreeTermCondition).click();
     cy.get(signInBttn).click();
   }
 
   loginasAStateUserWithCognito() {
-    cy.xpath(emailForCognito).type(testConfig.TEST_USER_3);
-    cy.xpath(passwordForCognito).type(testConfig.TEST_PASSWORD_1);
+    cy.xpath(emailForCognito).type(Cypress.env("TEST_USER_3"));
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
     cy.xpath(loginWithCognitoButtn).click();
   }
 
   loginasAStateUserTwoWithCognito() {
-    cy.xpath(emailForCognito).type(testConfig.TEST_USER_2);
-    cy.xpath(passwordForCognito).type(testConfig.TEST_PASSWORD_1);
+    cy.xpath(emailForCognito).type(Cypress.env("TEST_USER_2"));
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
     cy.xpath(loginWithCognitoButtn).click();
   }
 
   loginasApproverCognito() {
     cy.xpath(emailForCognito).type("adminuser@test.com");
-    cy.xpath(passwordForCognito).type(testConfig.TEST_PASSWORD_1);
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
     cy.xpath(loginWithCognitoButtn).click();
   }
   clickGoToStateHome() {

--- a/tests/cypress/support/pages/LoginPage.js
+++ b/tests/cypress/support/pages/LoginPage.js
@@ -10,15 +10,15 @@ const goToStateHomeBTN = "//button[contains(text(),'Go To State Home')]";
 export class LoginPage {
   enterUserName() {
     //cy.get(usernameInput).type("State_QMR2");
-    cy.get(usernameInput).type(Cypress.env("TEST_USER_3"));
+    cy.get(usernameInput).type(Cypress.env("CYPRESS_USER_3"));
   }
 
   enterEmailwithCognitoLogin() {
-    cy.xpath(emailForCognito).type(Cypress.env("TEST_USER_3"));
+    cy.xpath(emailForCognito).type(Cypress.env("CYPRESS_USER_3"));
   }
 
   enterPasswordwithCognitoLogin() {
-    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
+    cy.xpath(passwordForCognito).type(Cypress.env("CYPRESS_PASSWORD_1"));
   }
 
   clickLoginWithCognitoButtn() {
@@ -26,11 +26,11 @@ export class LoginPage {
   }
 
   enterEmailwithCognitoLogin() {
-    cy.xpath(emailForCognito).type(Cypress.env("TEST_USER_2"));
+    cy.xpath(emailForCognito).type(Cypress.env("CYPRESS_USER_2"));
   }
 
   enterPasswordwithCognitoLogin() {
-    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
+    cy.xpath(passwordForCognito).type(Cypress.env("CYPRESS_PASSWORD_1"));
   }
 
   clickLoginWithCognitoButtn() {
@@ -38,7 +38,7 @@ export class LoginPage {
   }
 
   enterPassword() {
-    cy.get(passwordInput).type(Cypress.env("TEST_PASSWORD_1"));
+    cy.get(passwordInput).type(Cypress.env("CYPRESS_PASSWORD_1"));
   }
 
   //old credentials
@@ -54,27 +54,27 @@ export class LoginPage {
   }
 
   loginasAStateUser() {
-    cy.get(usernameInput).type(Cypress.env("TEST_USER_2"));
-    cy.get(passwordInput).type(Cypress.env("TEST_PASSWORD_1"));
+    cy.get(usernameInput).type(Cypress.env("CYPRESS_USER_2"));
+    cy.get(passwordInput).type(Cypress.env("CYPRESS_PASSWORD_1"));
     cy.get(agreeTermCondition).click();
     cy.get(signInBttn).click();
   }
 
   loginasAStateUserWithCognito() {
-    cy.xpath(emailForCognito).type(Cypress.env("TEST_USER_3"));
-    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
+    cy.xpath(emailForCognito).type(Cypress.env("CYPRESS_USER_3"));
+    cy.xpath(passwordForCognito).type(Cypress.env("CYPRESS_PASSWORD_1"));
     cy.xpath(loginWithCognitoButtn).click();
   }
 
   loginasAStateUserTwoWithCognito() {
-    cy.xpath(emailForCognito).type(Cypress.env("TEST_USER_2"));
-    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
+    cy.xpath(emailForCognito).type(Cypress.env("CYPRESS_USER_2"));
+    cy.xpath(passwordForCognito).type(Cypress.env("CYPRESS_PASSWORD_1"));
     cy.xpath(loginWithCognitoButtn).click();
   }
 
   loginasApproverCognito() {
     cy.xpath(emailForCognito).type("adminuser@test.com");
-    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
+    cy.xpath(passwordForCognito).type(Cypress.env("CYPRESS_PASSWORD_1"));
     cy.xpath(loginWithCognitoButtn).click();
   }
   clickGoToStateHome() {

--- a/tests/cypress/support/pages/LoginPage.js
+++ b/tests/cypress/support/pages/LoginPage.js
@@ -10,15 +10,15 @@ const goToStateHomeBTN = "//button[contains(text(),'Go To State Home')]";
 export class LoginPage {
   enterUserName() {
     //cy.get(usernameInput).type("State_QMR2");
-    cy.get(usernameInput).type(Cypress.env("CYPRESS_USER_3"));
+    cy.get(usernameInput).type(Cypress.env("USER_3"));
   }
 
   enterEmailwithCognitoLogin() {
-    cy.xpath(emailForCognito).type(Cypress.env("CYPRESS_USER_3"));
+    cy.xpath(emailForCognito).type(Cypress.env("USER_3"));
   }
 
   enterPasswordwithCognitoLogin() {
-    cy.xpath(passwordForCognito).type(Cypress.env("CYPRESS_PASSWORD_1"));
+    cy.xpath(passwordForCognito).type(Cypress.env("PASSWORD_1"));
   }
 
   clickLoginWithCognitoButtn() {
@@ -26,11 +26,11 @@ export class LoginPage {
   }
 
   enterEmailwithCognitoLogin() {
-    cy.xpath(emailForCognito).type(Cypress.env("CYPRESS_USER_2"));
+    cy.xpath(emailForCognito).type(Cypress.env("USER_2"));
   }
 
   enterPasswordwithCognitoLogin() {
-    cy.xpath(passwordForCognito).type(Cypress.env("CYPRESS_PASSWORD_1"));
+    cy.xpath(passwordForCognito).type(Cypress.env("PASSWORD_1"));
   }
 
   clickLoginWithCognitoButtn() {
@@ -38,7 +38,7 @@ export class LoginPage {
   }
 
   enterPassword() {
-    cy.get(passwordInput).type(Cypress.env("CYPRESS_PASSWORD_1"));
+    cy.get(passwordInput).type(Cypress.env("PASSWORD_1"));
   }
 
   //old credentials
@@ -54,27 +54,27 @@ export class LoginPage {
   }
 
   loginasAStateUser() {
-    cy.get(usernameInput).type(Cypress.env("CYPRESS_USER_2"));
-    cy.get(passwordInput).type(Cypress.env("CYPRESS_PASSWORD_1"));
+    cy.get(usernameInput).type(Cypress.env("USER_2"));
+    cy.get(passwordInput).type(Cypress.env("PASSWORD_1"));
     cy.get(agreeTermCondition).click();
     cy.get(signInBttn).click();
   }
 
   loginasAStateUserWithCognito() {
-    cy.xpath(emailForCognito).type(Cypress.env("CYPRESS_USER_3"));
-    cy.xpath(passwordForCognito).type(Cypress.env("CYPRESS_PASSWORD_1"));
+    cy.xpath(emailForCognito).type(Cypress.env("USER_3"));
+    cy.xpath(passwordForCognito).type(Cypress.env("PASSWORD_1"));
     cy.xpath(loginWithCognitoButtn).click();
   }
 
   loginasAStateUserTwoWithCognito() {
-    cy.xpath(emailForCognito).type(Cypress.env("CYPRESS_USER_2"));
-    cy.xpath(passwordForCognito).type(Cypress.env("CYPRESS_PASSWORD_1"));
+    cy.xpath(emailForCognito).type(Cypress.env("USER_2"));
+    cy.xpath(passwordForCognito).type(Cypress.env("PASSWORD_1"));
     cy.xpath(loginWithCognitoButtn).click();
   }
 
   loginasApproverCognito() {
     cy.xpath(emailForCognito).type("adminuser@test.com");
-    cy.xpath(passwordForCognito).type(Cypress.env("CYPRESS_PASSWORD_1"));
+    cy.xpath(passwordForCognito).type(Cypress.env("PASSWORD_1"));
     cy.xpath(loginWithCognitoButtn).click();
   }
   clickGoToStateHome() {

--- a/tests/cypress/support/pages/LoginPage.js
+++ b/tests/cypress/support/pages/LoginPage.js
@@ -10,15 +10,15 @@ const goToStateHomeBTN = "//button[contains(text(),'Go To State Home')]";
 export class LoginPage {
   enterUserName() {
     //cy.get(usernameInput).type("State_QMR2");
-    cy.get(usernameInput).type(Cypress.env("USER_3"));
+    cy.get(usernameInput).type(Cypress.env("TEST_USER_3"));
   }
 
   enterEmailwithCognitoLogin() {
-    cy.xpath(emailForCognito).type(Cypress.env("USER_3"));
+    cy.xpath(emailForCognito).type(Cypress.env("TEST_USER_3"));
   }
 
   enterPasswordwithCognitoLogin() {
-    cy.xpath(passwordForCognito).type(Cypress.env("PASSWORD_1"));
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
   }
 
   clickLoginWithCognitoButtn() {
@@ -26,11 +26,11 @@ export class LoginPage {
   }
 
   enterEmailwithCognitoLogin() {
-    cy.xpath(emailForCognito).type(Cypress.env("USER_2"));
+    cy.xpath(emailForCognito).type(Cypress.env("TEST_USER_2"));
   }
 
   enterPasswordwithCognitoLogin() {
-    cy.xpath(passwordForCognito).type(Cypress.env("PASSWORD_1"));
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
   }
 
   clickLoginWithCognitoButtn() {
@@ -38,7 +38,7 @@ export class LoginPage {
   }
 
   enterPassword() {
-    cy.get(passwordInput).type(Cypress.env("PASSWORD_1"));
+    cy.get(passwordInput).type(Cypress.env("TEST_PASSWORD_1"));
   }
 
   //old credentials
@@ -54,27 +54,27 @@ export class LoginPage {
   }
 
   loginasAStateUser() {
-    cy.get(usernameInput).type(Cypress.env("USER_2"));
-    cy.get(passwordInput).type(Cypress.env("PASSWORD_1"));
+    cy.get(usernameInput).type(Cypress.env("TEST_USER_2"));
+    cy.get(passwordInput).type(Cypress.env("TEST_PASSWORD_1"));
     cy.get(agreeTermCondition).click();
     cy.get(signInBttn).click();
   }
 
   loginasAStateUserWithCognito() {
-    cy.xpath(emailForCognito).type(Cypress.env("USER_3"));
-    cy.xpath(passwordForCognito).type(Cypress.env("PASSWORD_1"));
+    cy.xpath(emailForCognito).type(Cypress.env("TEST_USER_3"));
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
     cy.xpath(loginWithCognitoButtn).click();
   }
 
   loginasAStateUserTwoWithCognito() {
-    cy.xpath(emailForCognito).type(Cypress.env("USER_2"));
-    cy.xpath(passwordForCognito).type(Cypress.env("PASSWORD_1"));
+    cy.xpath(emailForCognito).type(Cypress.env("TEST_USER_2"));
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
     cy.xpath(loginWithCognitoButtn).click();
   }
 
   loginasApproverCognito() {
     cy.xpath(emailForCognito).type("adminuser@test.com");
-    cy.xpath(passwordForCognito).type(Cypress.env("PASSWORD_1"));
+    cy.xpath(passwordForCognito).type(Cypress.env("TEST_PASSWORD_1"));
     cy.xpath(loginWithCognitoButtn).click();
   }
   clickGoToStateHome() {


### PR DESCRIPTION
this changes the output of configureLocal.sh in test/cypress to export a cypress.env.json file to be used locally and imports envars to be used in pipeline. This fixes an issue where env vars were not available when running tests (the cy.type() empty string thing)

as a result folks will prob need to run configureLocal.sh again or adjust the test-config file in place.