### PR TITLE
Allow PerformanceMeasure to use a custom NDR component

### DIFF
--- a/services/ui-src/src/components/index.tsx
+++ b/services/ui-src/src/components/index.tsx
@@ -21,6 +21,7 @@ export * from "./Logo";
 export * from "./MeasureButtons";
 export * from "./MeasureWrapper";
 export * from "./MonthPicker";
+export * from "./MultiRate";
 export * from "./MultiSelect";
 export * from "./Notification";
 export * from "./ProgressCircle";

--- a/services/ui-src/src/measures/2021/PCRAD/data.ts
+++ b/services/ui-src/src/measures/2021/PCRAD/data.ts
@@ -19,7 +19,7 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
     "For beneficiaries ages 18 to 64, the number of acute inpatient and observation stays during the measurement year that were followed by an unplanned acute readmission for any diagnosis within 30 days and the predicted probability of an acute readmission. Data are reported in the following categories:",
   ],
   questionListItems: [
-    "Count of Index Hospital Stays (IHS) ",
+    "Count of Index Hospital Stays (IHS)",
     "Count of Observed 30-Day Readmissions",
     "Count of Expected 30-Day Readmissions",
   ],

--- a/services/ui-src/src/measures/CommonQuestions/PerformanceMeasure/index.test.tsx
+++ b/services/ui-src/src/measures/CommonQuestions/PerformanceMeasure/index.test.tsx
@@ -1,0 +1,164 @@
+import {
+  exampleData,
+  PerformanceMeasureData,
+} from "measures/CommonQuestions/PerformanceMeasure/data";
+import { data as PCRData } from "measures/2021/PCRAD/data";
+import fireEvent from "@testing-library/user-event";
+import { PerformanceMeasure } from ".";
+import { renderWithHookForm } from "utils/testUtils/reactHookFormRenderer";
+import { screen } from "@testing-library/react";
+import { MultiRate } from "components";
+
+interface Props {
+  component: any;
+  calcTotal: boolean;
+  data: PerformanceMeasureData;
+  rateReadOnly: undefined | boolean;
+}
+
+const renderComponet = ({ component, calcTotal, data, rateReadOnly }: Props) =>
+  renderWithHookForm(
+    <PerformanceMeasure
+      data={data}
+      calcTotal={calcTotal}
+      RateComponent={component}
+      rateReadOnly={rateReadOnly}
+    />
+  );
+
+// TODO: Mock the datasource change to trigger rate editability
+describe("Test the PerformanceMeasure RateComponent prop", () => {
+  let props: Props;
+  beforeEach(() => {
+    props = {
+      component: undefined, // QMR.Rate is default
+      calcTotal: false,
+      data: exampleData,
+      rateReadOnly: undefined,
+    };
+  });
+
+  test("(QMR.Rate) Ensure component renders", () => {
+    renderComponet(props);
+    // should render QMR.Rate layout using example data
+    expect(screen.getByText(/Performance Measure/i)).toBeVisible();
+    expect(screen.getByText(exampleData.questionText![0])).toBeVisible();
+    expect(screen.getByText(exampleData.questionListItems![0])).toBeVisible();
+    expect(screen.getByText(exampleData.questionListItems![1])).toBeVisible();
+    for (const label of exampleData.qualifiers!)
+      expect(screen.queryAllByText(label).length).toBe(
+        exampleData.categories!.length
+      );
+    for (const label of exampleData.categories!)
+      expect(screen.getByText(label)).toBeVisible;
+
+    const numeratorTextBox = screen.queryAllByLabelText("Numerator")[0];
+    const denominatorTextBox = screen.queryAllByLabelText("Denominator")[0];
+    const rateTextBox = screen.queryAllByLabelText("Rate")[0];
+    fireEvent.type(numeratorTextBox, "123");
+    fireEvent.type(denominatorTextBox, "123");
+    expect(rateTextBox).toHaveDisplayValue("100.0");
+
+    // rates should be editable by default
+    fireEvent.type(rateTextBox, "99.9");
+    expect(rateTextBox).toHaveDisplayValue("99.9");
+
+    // last NDR in categroy should not total
+    const lastNumeratorTextBox = screen.queryAllByLabelText("Numerator")[1];
+    const lastDenominatorTextBox = screen.queryAllByLabelText("Denominator")[1];
+    const lastRateTextBox = screen.queryAllByLabelText("Rate")[1];
+    expect(lastNumeratorTextBox).toHaveDisplayValue("");
+    expect(lastDenominatorTextBox).toHaveDisplayValue("");
+    expect(lastRateTextBox).toHaveDisplayValue("");
+  });
+
+  test("(QMR.Rate) Rates should not be editable", () => {
+    props.rateReadOnly = true;
+    renderComponet(props);
+
+    const numeratorTextBox = screen.queryAllByLabelText("Numerator")[0];
+    const denominatorTextBox = screen.queryAllByLabelText("Denominator")[0];
+    const rateTextBox = screen.queryAllByLabelText("Rate")[0];
+    fireEvent.type(numeratorTextBox, "123");
+    fireEvent.type(denominatorTextBox, "123");
+    expect(rateTextBox).toHaveDisplayValue("100.0");
+
+    fireEvent.type(rateTextBox, "99.9");
+    expect(rateTextBox).toHaveDisplayValue("100.0");
+  });
+
+  test("(QMR.Rate) Should total in last NDR", () => {
+    props.calcTotal = true;
+    renderComponet(props);
+
+    const numeratorTextBox = screen.queryAllByLabelText("Numerator")[0];
+    const denominatorTextBox = screen.queryAllByLabelText("Denominator")[0];
+    const rateTextBox = screen.queryAllByLabelText("Rate")[0];
+    fireEvent.type(numeratorTextBox, "123");
+    fireEvent.type(denominatorTextBox, "123");
+    expect(numeratorTextBox).toHaveDisplayValue("123");
+    expect(denominatorTextBox).toHaveDisplayValue("123");
+    expect(rateTextBox).toHaveDisplayValue("100.0");
+
+    // last NDR set should not total
+    const lastNumeratorTextBox = screen.queryAllByLabelText("Numerator")[1];
+    const lastDenominatorTextBox = screen.queryAllByLabelText("Denominator")[1];
+    const lastRateTextBox = screen.queryAllByLabelText("Rate")[1];
+    expect(lastNumeratorTextBox).toHaveDisplayValue("123");
+    expect(lastDenominatorTextBox).toHaveDisplayValue("123");
+    expect(lastRateTextBox).toHaveDisplayValue("100.0");
+  });
+
+  test("(PCR-XX) Ensure component renders", () => {
+    // modifying data to be easier to check
+    PCRData.qualifiers = PCRData.qualifiers!.map((qual) => `qual ${qual}`);
+
+    props.component = MultiRate;
+    props.data = PCRData;
+    renderComponet(props);
+
+    // should render match MultiRate layout using PCR-XX data
+    expect(screen.getByText(/Performance Measure/i)).toBeVisible();
+    expect(screen.getByText(PCRData.questionText![0])).toBeVisible();
+    expect(screen.getByText(PCRData.questionListItems![0])).toBeVisible();
+    expect(screen.getByText(PCRData.questionListItems![1])).toBeVisible();
+    for (const label of PCRData.qualifiers!) {
+      expect(screen.getByText(label)).toBeVisible();
+    }
+
+    // rates should be editable by default
+    const numeratorTextBox = screen.getByLabelText(PCRData.qualifiers[1]);
+    const denominatorTextBox = screen.getByLabelText(PCRData.qualifiers[0]);
+    const rateTextBox = screen.getByLabelText(PCRData.qualifiers[2]);
+    fireEvent.type(numeratorTextBox, "123");
+    fireEvent.type(denominatorTextBox, "123");
+    expect(numeratorTextBox).toHaveDisplayValue("123");
+    expect(denominatorTextBox).toHaveDisplayValue("123");
+    expect(rateTextBox).toHaveDisplayValue("100.0000");
+
+    fireEvent.type(rateTextBox, "123");
+    expect(rateTextBox).toHaveDisplayValue("123");
+  });
+
+  test("(PCR-XX) Rates should not be editable", () => {
+    props.component = MultiRate;
+    props.data = PCRData;
+    props.rateReadOnly = true;
+    renderComponet(props);
+
+    // rates should not be editable
+    const numeratorTextBox = screen.queryAllByLabelText(
+      PCRData.qualifiers![1]
+    )[0];
+    const denominatorTextBox = screen.queryAllByLabelText(
+      PCRData.qualifiers![0]
+    )[0];
+    const rateTextBox = screen.getByText(PCRData.qualifiers![2]).nextSibling;
+    fireEvent.type(numeratorTextBox, "123");
+    fireEvent.type(denominatorTextBox, "123");
+    expect(numeratorTextBox).toHaveDisplayValue("123");
+    expect(denominatorTextBox).toHaveDisplayValue("123");
+    expect(rateTextBox?.textContent).toEqual("100.0000");
+    expect(rateTextBox?.nodeName).toBe("P");
+  });
+});

--- a/services/ui-src/src/measures/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/CommonQuestions/PerformanceMeasure/index.tsx
@@ -15,6 +15,7 @@ interface Props {
   hybridMeasure?: boolean;
   showtextbox?: boolean;
   allowNumeratorGreaterThanDenominator?: boolean;
+  RateComponent?: any;
 }
 
 interface NdrSetProps {
@@ -25,6 +26,7 @@ interface NdrSetProps {
   rateScale?: number;
   customMask?: RegExp;
   allowNumeratorGreaterThanDenominator?: boolean;
+  RateComponent: any;
 }
 
 /** Maps over the categories given and creates rate sets based on the qualifiers, with a default of one rate */
@@ -36,6 +38,7 @@ const CategoryNdrSets = ({
   customMask,
   allowNumeratorGreaterThanDenominator,
   calcTotal,
+  RateComponent,
 }: NdrSetProps) => {
   const register = useCustomRegister();
 
@@ -56,7 +59,7 @@ const CategoryNdrSets = ({
             <CUI.Text fontWeight="bold" my="5">
               {item}
             </CUI.Text>
-            <QMR.Rate
+            <RateComponent
               readOnly={rateReadOnly}
               rates={rates}
               rateMultiplicationValue={rateScale}
@@ -84,6 +87,7 @@ const QualifierNdrSets = ({
   customMask,
   calcTotal,
   allowNumeratorGreaterThanDenominator,
+  RateComponent,
 }: NdrSetProps) => {
   const register = useCustomRegister();
 
@@ -93,7 +97,7 @@ const QualifierNdrSets = ({
   }));
   return (
     <>
-      <QMR.Rate
+      <RateComponent
         rates={rates}
         readOnly={rateReadOnly}
         rateMultiplicationValue={rateScale}
@@ -145,6 +149,7 @@ export const PerformanceMeasure = ({
   hybridMeasure,
   allowNumeratorGreaterThanDenominator,
   showtextbox = true,
+  RateComponent = QMR.Rate, // Default to QMR.Rate
 }: Props) => {
   const register = useCustomRegister<Types.PerformanceMeasure>();
   const dataSourceWatch = useWatch<Types.DataSource>({
@@ -239,6 +244,7 @@ export const PerformanceMeasure = ({
         Please review the auto-calculated rate and revise if needed.
       </CUI.Heading>
       <PerformanceMeasureNdrs
+        RateComponent={RateComponent}
         categories={data.categories}
         qualifiers={data.qualifiers}
         rateReadOnly={readOnly}


### PR DESCRIPTION
## Purpose

Optionally pass an NDR component into the `CMQ.PerformanceMeasure` component so that measures such as PCR-AD, PCR-HH, IU-HH, etc. will not have to create a one-off component.

#### Linked Issues to Close

??

## Approach

- Create a new prop `RateComponent` on PerformanceMeasure will be used in place of `QMR.Rate`.
- Default to `QMR.Rate` for backwards compatibility and most common use-cases
- Add baseline unit testing for PerformanceMeasure that verifies the new pattern works 

## Assorted Notes/Considerations

By increasing the flexibility of the PerformanceMeasure component, we will ensure that these unique measures will be up to date with any changes made to the global component. Currently, PCR-AD and PCR-HH both have their own PM and OMS components, both of which are now out of date. IU-HH will follow this same pattern as will any other measure with a unique NDR component.

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
