### PR TITLE
Oy2 18262 - Adding two selections to "Why are you not reporting on this measure" for all Health Home Measures/HH text updates

### DIFF
--- a/services/app-api/handlers/dynamoUtils/measureList.ts
+++ b/services/app-api/handlers/dynamoUtils/measureList.ts
@@ -404,7 +404,7 @@ export const measures: Measure = {
     },
     {
       type: "H",
-      description: "Follow-Up after Hosptialization for Mental Illness",
+      description: "Follow-Up after Hospitalization for Mental Illness",
       measure: "FUH-HH",
     },
     {
@@ -415,7 +415,7 @@ export const measures: Measure = {
     },
     {
       type: "H",
-      description: "Inpatient Hospitalization",
+      description: "Inpatient Utilization",
       measure: "IU-HH",
     },
     {

--- a/services/ui-src/src/dataConstants.ts
+++ b/services/ui-src/src/dataConstants.ts
@@ -23,9 +23,13 @@ export const COMBINED_WEIGHTED_RATES = "Combined Weighted Rates";
 export const COMBINED_WEIGHTED_RATES_OTHER = "Combined Weighted Rates Other";
 export const COMBINED_WEIGHTED_RATES_OTHER_EXPLAINATION =
   "CombinedRates-CombinedRates-Other-Explanation";
+export const CONTINUOUS_ENROLLMENT_REQUIREMENT_NOT_MET_DUE_TO_START_DATE_OF_SPA =
+  "ContinuousEnrollmentRequirementNotMetDueToStartDateOfSPA";
 export const DATA_INCONSISTENCIES_ACCURACY_ISSUES =
   "DataInconsistenciesAccuracyIssues";
 export const DATA_NOT_AVAILABLE = "DataNotAvailable";
+export const DATA_NOT_SUBMITTED_BY_PROVIDERS_TO_STATE =
+  "DataNotSubmittedByProvidersToState";
 export const DATA_SOURCE = "DataSource";
 export const DATA_SOURCE_DESCRIPTION = "DataSourceDescription";
 export const DATA_SOURCE_NOT_EASILY_ACCESSIBLE =

--- a/services/ui-src/src/measures/2021/FUAHH/data.ts
+++ b/services/ui-src/src/measures/2021/FUAHH/data.ts
@@ -16,8 +16,8 @@ export const data: DataDrivenTypes.PerformanceMeasure = {
     "Percentage of emergency department (ED) visits for Health Home enrollees age 13 and older with a principal diagnosis of alcohol or other drug (AOD) abuse or dependence who had a follow-up visit for AOD abuse or dependence.  Two rates are reported:",
   ],
   questionListItems: [
-    "Percentage of ED visits for which the beneficiary received follow-up within 30 days of the ED visit (31 total days)",
-    "Percentage of ED visits for which the beneficiary received follow-up within 7 days of the ED visit (8 total days)",
+    "Percentage of ED visits for which the enrollee received follow-up within 30 days of the ED visit (31 total days)",
+    "Percentage of ED visits for which the enrollee received follow-up within 7 days of the ED visit (8 total days)",
   ],
   categories,
   qualifiers,

--- a/services/ui-src/src/measures/2021/FUAHH/index.tsx
+++ b/services/ui-src/src/measures/2021/FUAHH/index.tsx
@@ -34,6 +34,7 @@ export const FUAHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
+        healthHomeMeasure
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2021/PCRHH/index.tsx
@@ -35,6 +35,7 @@ export const PCRHH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
+        healthHomeMeasure
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/PQI92HH/index.tsx
+++ b/services/ui-src/src/measures/2021/PQI92HH/index.tsx
@@ -34,6 +34,7 @@ export const PQI92HH = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
+        healthHomeMeasure
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/CommonQuestions/DefinitionsOfPopulation/index.tsx
+++ b/services/ui-src/src/measures/CommonQuestions/DefinitionsOfPopulation/index.tsx
@@ -20,6 +20,7 @@ export const DefinitionOfPopulation = ({
   healthHomeMeasure,
 }: Props) => {
   const register = useCustomRegister<Types.DefinitionOfPopulation>();
+  console.log(healthHomeMeasure);
 
   return (
     <QMR.CoreQuestionWrapper label="Definition of Population Included in the Measure">

--- a/services/ui-src/src/measures/CommonQuestions/DefinitionsOfPopulation/index.tsx
+++ b/services/ui-src/src/measures/CommonQuestions/DefinitionsOfPopulation/index.tsx
@@ -29,9 +29,11 @@ export const DefinitionOfPopulation = ({
       {!childMeasure && (
         <CUI.Box>
           <CUI.Text mt="3">
-            Please select all populations that are included. For example, if
-            your data include both non-dual Medicaid beneficiaries and Medicare
-            and Medicaid Dual Eligibles, select both:
+            {`Please select all populations that are included. For example, if
+            your data include both non-dual Medicaid ${
+              healthHomeMeasure ? "enrollees" : "beneficiaries"
+            } and Medicare
+            and Medicaid Dual Eligibles, select both:`}
           </CUI.Text>
           <CUI.UnorderedList m="5" ml="10">
             <CUI.ListItem>

--- a/services/ui-src/src/measures/CommonQuestions/DefinitionsOfPopulation/index.tsx
+++ b/services/ui-src/src/measures/CommonQuestions/DefinitionsOfPopulation/index.tsx
@@ -20,7 +20,6 @@ export const DefinitionOfPopulation = ({
   healthHomeMeasure,
 }: Props) => {
   const register = useCustomRegister<Types.DefinitionOfPopulation>();
-  console.log(healthHomeMeasure);
 
   return (
     <QMR.CoreQuestionWrapper label="Definition of Population Included in the Measure">

--- a/services/ui-src/src/measures/CommonQuestions/DefinitionsOfPopulation/index.tsx
+++ b/services/ui-src/src/measures/CommonQuestions/DefinitionsOfPopulation/index.tsx
@@ -29,11 +29,9 @@ export const DefinitionOfPopulation = ({
       {!childMeasure && (
         <CUI.Box>
           <CUI.Text mt="3">
-            {`Please select all populations that are included. For example, if
-            your data include both non-dual Medicaid ${
+            {`Please select all populations that are included. For example, if your data include both non-dual Medicaid ${
               healthHomeMeasure ? "enrollees" : "beneficiaries"
-            } and Medicare
-            and Medicaid Dual Eligibles, select both:`}
+            } and Medicare and Medicaid Dual Eligibles, select both:`}
           </CUI.Text>
           <CUI.UnorderedList m="5" ml="10">
             <CUI.ListItem>

--- a/services/ui-src/src/measures/CommonQuestions/Reporting/index.tsx
+++ b/services/ui-src/src/measures/CommonQuestions/Reporting/index.tsx
@@ -9,12 +9,14 @@ interface Props {
   measureName: string;
   measureAbbreviation: string;
   reportingYear: string;
+  healthHomeMeasure?: boolean;
 }
 
 export const Reporting = ({
   measureName,
   reportingYear,
   measureAbbreviation,
+  healthHomeMeasure,
 }: Props) => {
   const register = useCustomRegister<Types.DidReport>();
   const { watch } = useFormContext<Types.DidReport>();
@@ -37,7 +39,9 @@ export const Reporting = ({
           ]}
         />
       </QMR.CoreQuestionWrapper>
-      {watchRadioStatus === DC.NO && <WhyAreYouNotReporting />}
+      {watchRadioStatus === DC.NO && (
+        <WhyAreYouNotReporting healthHomeMeasure={healthHomeMeasure} />
+      )}
     </>
   );
 };

--- a/services/ui-src/src/measures/CommonQuestions/WhyAreYouNotReporting/index.tsx
+++ b/services/ui-src/src/measures/CommonQuestions/WhyAreYouNotReporting/index.tsx
@@ -3,7 +3,11 @@ import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "../types";
 import * as DC from "dataConstants";
 
-export const WhyAreYouNotReporting = () => {
+interface Props {
+  healthHomeMeasure?: boolean;
+}
+
+export const WhyAreYouNotReporting = ({ healthHomeMeasure }: Props) => {
   const register = useCustomRegister<Types.WhyAreYouNotReporting>();
   return (
     <QMR.CoreQuestionWrapper label="Why are you not reporting on this measure?">
@@ -69,6 +73,15 @@ export const WhyAreYouNotReporting = () => {
                       />,
                     ],
                   },
+                  ...(healthHomeMeasure
+                    ? [
+                        {
+                          displayValue:
+                            "Data not submitted by Providers to State",
+                          value: DC.DATA_NOT_SUBMITTED_BY_PROVIDERS_TO_STATE,
+                        },
+                      ]
+                    : []),
                   {
                     displayValue: "Data source not easily accessible",
                     value: DC.DATA_SOURCE_NOT_EASILY_ACCESSIBLE,
@@ -165,6 +178,16 @@ export const WhyAreYouNotReporting = () => {
               />,
             ],
           },
+          ...(healthHomeMeasure
+            ? [
+                {
+                  displayValue:
+                    "Continuous enrollment requirement not met due to start date of SPA",
+                  value:
+                    DC.CONTINUOUS_ENROLLMENT_REQUIREMENT_NOT_MET_DUE_TO_START_DATE_OF_SPA,
+                },
+              ]
+            : []),
           {
             displayValue: "Other",
             value: DC.OTHER,

--- a/services/ui-src/src/measures/measuresList.ts
+++ b/services/ui-src/src/measures/measuresList.ts
@@ -319,7 +319,7 @@ export const measuresList: MeasureList = {
     },
     {
       type: "HH",
-      name: "Follow-Up after Hosptialization for Mental Illness",
+      name: "Follow-Up after Hospitalization for Mental Illness",
       measureId: "FUH-HH",
     },
     {
@@ -329,7 +329,7 @@ export const measuresList: MeasureList = {
     },
     {
       type: "HH",
-      name: "Inpatient Hospitalization",
+      name: "Inpatient Utilization",
       measureId: "IU-HH",
     },
     {

--- a/tests/cypress/cypress/integration/measures/PCRHH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/PCRHH.spec.ts
@@ -362,4 +362,185 @@ describe("PCR-HH", () => {
 
     cy.get('[data-cy="Validate Measure"]').click();
   });
+
+  it("Verify the selections for Not reporting on this measure for Health Home measures only", function () {
+    cy.get('[data-cy="DidReport1"]').click();
+    cy.get("#DidReport-no").should(
+      "have.text",
+      "No, I am not reporting Plan All-Cause Readmissions (PCR-HH) for FFY 2021 quality measure reporting."
+    );
+    cy.get('[data-cy="Why are you not reporting on this measure?"]').should(
+      "have.text",
+      "Why are you not reporting on this measure?"
+    );
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting0"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Service not covered");
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting0"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyAreYouNotReporting0-checkbox").check();
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting1"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Population not covered");
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting1"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyAreYouNotReporting1-checkbox").check();
+    cy.get("#AmountOfPopulationNotCovered-EntirePopulationNotCovered").should(
+      "have.text",
+      "Entire population not covered"
+    );
+    cy.get("#AmountOfPopulationNotCovered-PartialPopulationNotCovered").should(
+      "have.text",
+      "Partial population not covered"
+    );
+    cy.get('[data-cy="AmountOfPopulationNotCovered0"]').click();
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting2"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Data not available");
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting2"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyAreYouNotReporting2-checkbox").check();
+    cy.get('[data-cy="Why is data not available?"]').should(
+      "have.text",
+      "Why is data not available?"
+    );
+    cy.get(
+      '[data-cy="WhyIsDataNotAvailable0"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Budget constraints");
+    cy.get(
+      '[data-cy="WhyIsDataNotAvailable0"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyIsDataNotAvailable0-checkbox").check();
+    cy.get(
+      '[data-cy="WhyIsDataNotAvailable1"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Staff Constraints");
+    cy.get(
+      '[data-cy="WhyIsDataNotAvailable1"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyIsDataNotAvailable1-checkbox").check();
+    cy.get(
+      '[data-cy="WhyIsDataNotAvailable2"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Data inconsistencies/Accuracy");
+    cy.get(
+      '[data-cy="WhyIsDataNotAvailable2"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyIsDataNotAvailable2-checkbox").check();
+    cy.get(
+      '[data-cy="WhyIsDataNotAvailable3"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Data not submitted by Providers to State");
+    cy.get(
+      '[data-cy="WhyIsDataNotAvailable3"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyIsDataNotAvailable3-checkbox").check();
+    cy.get(
+      '[data-cy="WhyIsDataNotAvailable4"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Data source not easily accessible");
+    cy.get(
+      '[data-cy="WhyIsDataNotAvailable4"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyIsDataNotAvailable4-checkbox").check();
+    cy.get(
+      '[data-cy="DataSourceNotEasilyAccessible0"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Requires medical record review");
+    cy.get(
+      '[data-cy="DataSourceNotEasilyAccessible0"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#DataSourceNotEasilyAccessible0-checkbox").check();
+    cy.get(
+      '[data-cy="DataSourceNotEasilyAccessible1"] > .chakra-checkbox__label > .chakra-text'
+    ).should(
+      "have.text",
+      "Requires data linkage which does not currently exist"
+    );
+    cy.get(
+      '[data-cy="DataSourceNotEasilyAccessible1"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#DataSourceNotEasilyAccessible1-checkbox").check();
+    cy.get(
+      '[data-cy="DataSourceNotEasilyAccessible2"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Other");
+    cy.get(
+      '[data-cy="DataSourceNotEasilyAccessible2"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#DataSourceNotEasilyAccessible2-checkbox").check();
+    cy.get(
+      '[data-cy="WhyIsDataNotAvailable5"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Information not collected");
+    cy.get(
+      '[data-cy="WhyIsDataNotAvailable5"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyIsDataNotAvailable5-checkbox").check();
+    cy.get(
+      '[data-cy="InformationNotCollected0"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Not Collected by Provider (Hospital/Health Plan)");
+    cy.get(
+      '[data-cy="InformationNotCollected0"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#InformationNotCollected0-checkbox").check();
+    cy.get(
+      '[data-cy="InformationNotCollected1"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Other");
+    cy.get(
+      '[data-cy="InformationNotCollected1"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#InformationNotCollected1-checkbox").check();
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting3"] > .chakra-checkbox__label > .chakra-text'
+    ).should(
+      "have.text",
+      "Limitations with data collection, reporting, or accuracy due to the COVID-19 pandemic"
+    );
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting3"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyAreYouNotReporting3-checkbox").check();
+    cy.get(
+      '[data-cy="Describe your state\'s limitations with regard to collection, reporting, or accuracy of data for this measure:"]'
+    ).should(
+      "have.text",
+      "Describe your state's limitations with regard to collection, reporting, or accuracy of data for this measure:"
+    );
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting4"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Small sample size (less than 30)");
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting4"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyAreYouNotReporting4-checkbox").check();
+    cy.get('[data-cy="Enter specific sample size:"]').should(
+      "have.text",
+      "Enter specific sample size:"
+    );
+    cy.get('[data-cy="SmallSampleSizeLessThan30"]').clear();
+    cy.get('[data-cy="SmallSampleSizeLessThan30"]').type("2");
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting5"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyAreYouNotReporting5-checkbox").check();
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting6"] > .chakra-checkbox__label > .chakra-text'
+    ).should("have.text", "Other");
+    cy.get(
+      '[data-cy="WhyAreYouNotReporting6"] > .chakra-checkbox__control'
+    ).click();
+    cy.get("#WhyAreYouNotReporting6-checkbox").check();
+    cy.get(
+      '[data-cy="Additional Notes/Comments on the measure (optional)"]'
+    ).should(
+      "have.text",
+      "Additional Notes/Comments on the measure (optional)"
+    );
+    cy.get(
+      '[data-cy="Please add any additional notes or comments on the measure not otherwise captured above:"]'
+    ).should(
+      "have.text",
+      "Please add any additional notes or comments on the measure not otherwise captured above:"
+    );
+    cy.get('[data-cy="AdditionalNotes-AdditionalNotes"]').click();
+    cy.get('[data-cy="AdditionalNotes-AdditionalNotes"]').type("Test");
+    cy.get('[data-cy="Validate Measure"]').click();
+  });
 });

--- a/tests/cypress/cypress/integration/measures/QUALIFIERS_healthhome.spec.ts
+++ b/tests/cypress/cypress/integration/measures/QUALIFIERS_healthhome.spec.ts
@@ -235,10 +235,10 @@ describe("Health Home Measure Qualifier: HH", () => {
       "FUA-HH - Follow-Up after Emergency Department Visit for Alcohol and Other Drug Abuse or Dependence"
     );
     cy.get(
-      '[data-cy="CoreSetMeasuresAuditedOrValidatedDetails.0.MeasuresAuditedOrValidated-FUH-HH - Follow-Up after Hosptialization for Mental Illness"]'
+      '[data-cy="CoreSetMeasuresAuditedOrValidatedDetails.0.MeasuresAuditedOrValidated-FUH-HH - Follow-Up after Hospitalization for Mental Illness"]'
     ).should(
       "have.text",
-      "FUH-HH - Follow-Up after Hosptialization for Mental Illness"
+      "FUH-HH - Follow-Up after Hospitalization for Mental Illness"
     );
     cy.get(
       '[data-cy="CoreSetMeasuresAuditedOrValidatedDetails.0.MeasuresAuditedOrValidated-IET-HH - Initiation and Engagement of Alcohol and Other Drug Abuse or Dependence Treatment"]'
@@ -247,8 +247,8 @@ describe("Health Home Measure Qualifier: HH", () => {
       "IET-HH - Initiation and Engagement of Alcohol and Other Drug Abuse or Dependence Treatment"
     );
     cy.get(
-      '[data-cy="CoreSetMeasuresAuditedOrValidatedDetails.0.MeasuresAuditedOrValidated-IU-HH - Inpatient Hospitalization"]'
-    ).should("have.text", "IU-HH - Inpatient Hospitalization");
+      '[data-cy="CoreSetMeasuresAuditedOrValidatedDetails.0.MeasuresAuditedOrValidated-IU-HH - Inpatient Utilization"]'
+    ).should("have.text", "IU-HH - Inpatient Utilization");
     cy.get(
       '[data-cy="CoreSetMeasuresAuditedOrValidatedDetails.0.MeasuresAuditedOrValidated-OUD-HH - Use of Pharmacotherapy for Opioid Use Disorder"]'
     ).should(


### PR DESCRIPTION
## Purpose
Adding two selections to "Why are you not reporting on this measure" for all Health Home Measures/HH text updates: (115, 116, 117, 120, 121)

#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-18262

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
