### PR TITLE
Oy2 18283 partialval

### DIFF
--- a/services/ui-src/src/measures/2021/ADDCH/validation.ts
+++ b/services/ui-src/src/measures/2021/ADDCH/validation.ts
@@ -31,7 +31,8 @@ const ADDCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/AMBCH/validation.ts
+++ b/services/ui-src/src/measures/2021/AMBCH/validation.ts
@@ -28,7 +28,8 @@ const AMBCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2021/AMMAD/validation.ts
+++ b/services/ui-src/src/measures/2021/AMMAD/validation.ts
@@ -91,7 +91,8 @@ const AMMADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateDualPopInformationPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/AMRAD/validation.ts
+++ b/services/ui-src/src/measures/2021/AMRAD/validation.ts
@@ -27,7 +27,8 @@ const AMRADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2021/AMRCH/validation.ts
+++ b/services/ui-src/src/measures/2021/AMRCH/validation.ts
@@ -27,7 +27,8 @@ const AMRCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateAtLeastOneDeviationFieldFilled(

--- a/services/ui-src/src/measures/2021/APMCH/validation.ts
+++ b/services/ui-src/src/measures/2021/APMCH/validation.ts
@@ -27,7 +27,8 @@ const APMCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      PMD.qualifiers
+      PMD.qualifiers,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/APPCH/validation.ts
+++ b/services/ui-src/src/measures/2021/APPCH/validation.ts
@@ -28,7 +28,8 @@ const APPCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      PMD.qualifiers
+      PMD.qualifiers,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/AUDCH/validation.ts
+++ b/services/ui-src/src/measures/2021/AUDCH/validation.ts
@@ -30,7 +30,8 @@ const AUDCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateDualPopInformationPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/BCSAD/validation.ts
+++ b/services/ui-src/src/measures/2021/BCSAD/validation.ts
@@ -30,7 +30,8 @@ const BCSValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateDualPopInformationPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/CBPAD/validation.ts
+++ b/services/ui-src/src/measures/2021/CBPAD/validation.ts
@@ -29,7 +29,8 @@ const CBPValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateDualPopInformationPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/CCPAD/validation.ts
+++ b/services/ui-src/src/measures/2021/CCPAD/validation.ts
@@ -28,7 +28,8 @@ const CCPADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateOneQualRateHigherThanOtherQualPM(data, PMD.data),

--- a/services/ui-src/src/measures/2021/CCPCH/validation.ts
+++ b/services/ui-src/src/measures/2021/CCPCH/validation.ts
@@ -28,7 +28,8 @@ const CCPCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateEqualCategoryDenominatorsPM(data, PMD.categories),

--- a/services/ui-src/src/measures/2021/CCSAD/validation.ts
+++ b/services/ui-src/src/measures/2021/CCSAD/validation.ts
@@ -51,7 +51,8 @@ const CCSADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/CCWAD/validation.ts
+++ b/services/ui-src/src/measures/2021/CCWAD/validation.ts
@@ -33,7 +33,8 @@ const CCWADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/CCWCH/validation.ts
+++ b/services/ui-src/src/measures/2021/CCWCH/validation.ts
@@ -28,7 +28,8 @@ const CCWCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/CDFAD/validation.ts
+++ b/services/ui-src/src/measures/2021/CDFAD/validation.ts
@@ -30,7 +30,8 @@ const CDFADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateDualPopInformationPM(

--- a/services/ui-src/src/measures/2021/CDFCH/validation.ts
+++ b/services/ui-src/src/measures/2021/CDFCH/validation.ts
@@ -30,7 +30,8 @@ const CDFCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateDualPopInformationPM(

--- a/services/ui-src/src/measures/2021/CHLAD/validation.ts
+++ b/services/ui-src/src/measures/2021/CHLAD/validation.ts
@@ -28,7 +28,8 @@ const CHLValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/CHLCH/validation.ts
+++ b/services/ui-src/src/measures/2021/CHLCH/validation.ts
@@ -28,7 +28,8 @@ const CHLValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/CISCH/validation.ts
+++ b/services/ui-src/src/measures/2021/CISCH/validation.ts
@@ -51,7 +51,8 @@ const CISCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/COBAD/validation.ts
+++ b/services/ui-src/src/measures/2021/COBAD/validation.ts
@@ -31,7 +31,8 @@ const IEDValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateDualPopInformationPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/DEVCH/validation.ts
+++ b/services/ui-src/src/measures/2021/DEVCH/validation.ts
@@ -46,7 +46,8 @@ const DEVCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2021/FUAAD/validation.ts
+++ b/services/ui-src/src/measures/2021/FUAAD/validation.ts
@@ -36,7 +36,8 @@ const FUAADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateDualPopInformationPM(

--- a/services/ui-src/src/measures/2021/FUAHH/validation.ts
+++ b/services/ui-src/src/measures/2021/FUAHH/validation.ts
@@ -39,7 +39,8 @@ const FUAHHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
 

--- a/services/ui-src/src/measures/2021/FUHAD/validation.ts
+++ b/services/ui-src/src/measures/2021/FUHAD/validation.ts
@@ -48,7 +48,8 @@ const FUHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/FUHCH/validation.ts
+++ b/services/ui-src/src/measures/2021/FUHCH/validation.ts
@@ -47,7 +47,8 @@ const FUHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/FUMAD/validation.ts
+++ b/services/ui-src/src/measures/2021/FUMAD/validation.ts
@@ -40,7 +40,8 @@ const FUMADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateDualPopInformationPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/FVAAD/validation.ts
+++ b/services/ui-src/src/measures/2021/FVAAD/validation.ts
@@ -29,7 +29,8 @@ const FVAADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/HPCAD/validation.ts
+++ b/services/ui-src/src/measures/2021/HPCAD/validation.ts
@@ -60,7 +60,8 @@ const HPCADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/HPCMIAD/validation.ts
+++ b/services/ui-src/src/measures/2021/HPCMIAD/validation.ts
@@ -31,7 +31,8 @@ const HPCMIADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateDualPopInformationPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/HVLAD/validation.ts
+++ b/services/ui-src/src/measures/2021/HVLAD/validation.ts
@@ -30,7 +30,8 @@ const HVLADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateDualPopInformationPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/IETAD/validation.ts
+++ b/services/ui-src/src/measures/2021/IETAD/validation.ts
@@ -96,7 +96,8 @@ const IETValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateDualPopInformationPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/IMACH/validation.ts
+++ b/services/ui-src/src/measures/2021/IMACH/validation.ts
@@ -46,7 +46,8 @@ const DEVCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2021/MSCAD/validation.ts
+++ b/services/ui-src/src/measures/2021/MSCAD/validation.ts
@@ -31,7 +31,8 @@ const MSCADValidation = (data: Types.DefaultFormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateDualPopInformationPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/OHDAD/validation.ts
+++ b/services/ui-src/src/measures/2021/OHDAD/validation.ts
@@ -30,7 +30,8 @@ const OHDValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateDualPopInformationPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/OUDAD/validation.ts
+++ b/services/ui-src/src/measures/2021/OUDAD/validation.ts
@@ -28,7 +28,8 @@ const OUDValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      PMD.qualifiers
+      PMD.qualifiers,
+      PMD.categories
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/PC01AD/validation.ts
+++ b/services/ui-src/src/measures/2021/PC01AD/validation.ts
@@ -38,7 +38,8 @@ const PC01ADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/PPCAD/validation.ts
+++ b/services/ui-src/src/measures/2021/PPCAD/validation.ts
@@ -51,7 +51,8 @@ const PPCADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/PPCCH/validation.ts
+++ b/services/ui-src/src/measures/2021/PPCCH/validation.ts
@@ -51,7 +51,8 @@ const PPCCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/PQI01AD/validation.ts
+++ b/services/ui-src/src/measures/2021/PQI01AD/validation.ts
@@ -35,7 +35,8 @@ const PQI01Validation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      PMD.qualifiers
+      PMD.qualifiers,
+      PMD.categories
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateNoNonZeroNumOrDenomPM(

--- a/services/ui-src/src/measures/2021/PQI05AD/validation.ts
+++ b/services/ui-src/src/measures/2021/PQI05AD/validation.ts
@@ -60,7 +60,8 @@ const PQI05Validation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateRequiredRadioButtonForCombinedRates(data),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2021/PQI08AD/validation.ts
+++ b/services/ui-src/src/measures/2021/PQI08AD/validation.ts
@@ -33,7 +33,8 @@ const PQI08Validation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      PMD.qualifiers
+      PMD.qualifiers,
+      PMD.categories
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateAtLeastOneDataSource(data),

--- a/services/ui-src/src/measures/2021/PQI15AD/validation.ts
+++ b/services/ui-src/src/measures/2021/PQI15AD/validation.ts
@@ -27,7 +27,8 @@ const PQI15Validation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateBothDatesCompleted(dateRange),
     ...GV.validateNoNonZeroNumOrDenomPM(

--- a/services/ui-src/src/measures/2021/PQI92HH/validation.ts
+++ b/services/ui-src/src/measures/2021/PQI92HH/validation.ts
@@ -39,7 +39,8 @@ const PQI92Validation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateNoNonZeroNumOrDenomPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/SAAAD/validation.ts
+++ b/services/ui-src/src/measures/2021/SAAAD/validation.ts
@@ -28,7 +28,8 @@ const SAAADValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
 
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/SFMCH/validation.ts
+++ b/services/ui-src/src/measures/2021/SFMCH/validation.ts
@@ -47,7 +47,8 @@ const SFMCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateOneQualRateHigherThanOtherQualPM(data, PMD),
     ...GV.validateNoNonZeroNumOrDenomPM(

--- a/services/ui-src/src/measures/2021/SSDAD/validation.ts
+++ b/services/ui-src/src/measures/2021/SSDAD/validation.ts
@@ -28,7 +28,8 @@ const SSDValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateNumeratorsLessThanDenominatorsPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/W30CH/validation.ts
+++ b/services/ui-src/src/measures/2021/W30CH/validation.ts
@@ -47,7 +47,8 @@ const W30CHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateNoNonZeroNumOrDenomPM(
       performanceMeasureArray,

--- a/services/ui-src/src/measures/2021/WCCCH/validation.ts
+++ b/services/ui-src/src/measures/2021/WCCCH/validation.ts
@@ -28,7 +28,8 @@ const WCCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      PMD.qualifiers
+      PMD.qualifiers,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/2021/WCVCH/validation.ts
+++ b/services/ui-src/src/measures/2021/WCVCH/validation.ts
@@ -51,7 +51,8 @@ const WCVCHValidation = (data: FormData) => {
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,
-      ageGroups
+      ageGroups,
+      PMD.categories
     ),
     ...GV.validateAtLeastOneDataSource(data),
     ...GV.validateNumeratorsLessThanDenominatorsPM(

--- a/services/ui-src/src/measures/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/measures/globalValidations/omsValidator/index.ts
@@ -7,6 +7,7 @@ import {
   OmsNodes as OMS,
   DefaultFormData,
 } from "measures/CommonQuestions/types";
+import { validatePartialRateCompletionOMS } from "../validatePartialRateCompletion";
 import { cleanString } from "utils/cleanString";
 
 interface OmsValidationProps {
@@ -129,8 +130,21 @@ const validateNDRs = (
         })
       );
     }
-    if (checkIsFilled)
+    if (checkIsFilled) {
       isFilled[label[0]] = isFilled[label[0]] || checkNdrsFilled(rateData);
+      errorArray.push(
+        ...validatePartialRateCompletionOMS({
+          rateData,
+          categories,
+          qualifiers,
+          label,
+          locationDictionary,
+          isOPM,
+          customTotalLabel,
+          dataSource,
+        })
+      );
+    }
 
     const locationReduced = label.reduce(
       (prev, curr, i) => `${prev}${i ? "-" : ""}${curr}`,

--- a/services/ui-src/src/measures/globalValidations/validateAtLeastOneRateComplete/index.ts
+++ b/services/ui-src/src/measures/globalValidations/validateAtLeastOneRateComplete/index.ts
@@ -25,6 +25,7 @@ export const validateAtLeastOneRateComplete = (
         performanceMeasureArray[index] &&
         performanceMeasureArray[index][i] &&
         performanceMeasureArray[index][i].denominator &&
+        performanceMeasureArray[index][i].rate &&
         performanceMeasureArray[index][i].numerator
       ) {
         rateCompletionError = false;

--- a/services/ui-src/src/measures/globalValidations/validateAtLeastOneRateComplete/index.ts
+++ b/services/ui-src/src/measures/globalValidations/validateAtLeastOneRateComplete/index.ts
@@ -1,22 +1,25 @@
 import { FormRateField } from "../types";
+import { validatePartialRateCompletionPM } from "../validatePartialRateCompletion";
 
 export const validateAtLeastOneRateComplete = (
   performanceMeasureArray: FormRateField[][],
   OPM: any,
-  ageGroups: string[]
+  qualifiers: string[],
+  categories?: string[]
 ) => {
-  let error = true;
-  let errorArray: FormError[] = [];
+  const errorArray: FormError[] = [];
+  let rateCompletionError = true;
+
   // Check OPM first
   OPM &&
     OPM.forEach((measure: any) => {
       if (measure.rate && measure.rate[0] && measure.rate[0].rate) {
-        error = false;
+        rateCompletionError = false;
       }
     });
 
   // Then Check regular Performance Measures
-  ageGroups.forEach((_ageGroup, i) => {
+  qualifiers.forEach((_ageGroup, i) => {
     performanceMeasureArray?.forEach((_performanceObj, index) => {
       if (
         performanceMeasureArray[index] &&
@@ -24,15 +27,23 @@ export const validateAtLeastOneRateComplete = (
         performanceMeasureArray[index][i].denominator &&
         performanceMeasureArray[index][i].numerator
       ) {
-        error = false;
+        rateCompletionError = false;
       }
     });
   });
-  if (error) {
+  if (rateCompletionError) {
     errorArray.push({
       errorLocation: `Performance Measure/Other Performance Measure`,
       errorMessage: `At least one Performance Measure Numerator, Denominator, and Rate must be completed`,
     });
   }
-  return error ? errorArray : [];
+  return [
+    ...errorArray,
+    ...validatePartialRateCompletionPM(
+      performanceMeasureArray,
+      OPM,
+      qualifiers,
+      categories
+    ),
+  ];
 };

--- a/services/ui-src/src/measures/globalValidations/validatePartialRateCompletion/index.test.ts
+++ b/services/ui-src/src/measures/globalValidations/validatePartialRateCompletion/index.test.ts
@@ -1,0 +1,180 @@
+import { SINGLE_CATEGORY } from "dataConstants";
+import {
+  validatePartialRateCompletionOMS,
+  validatePartialRateCompletionPM,
+} from "./index";
+import {
+  generateOmsCategoryRateData,
+  generateOtherPerformanceMeasureData,
+  locationDictionary,
+  simpleRate,
+  partialRate,
+} from "utils/testUtils/validationHelpers";
+
+describe("Testing Partial Rate Validation", () => {
+  const categories = ["Test Cat 1", "Test Cat 2"];
+  const qualifiers = ["Test Qual 1", "Test Qual 2"];
+
+  const baseOMSInfo = {
+    categories,
+    qualifiers,
+    locationDictionary,
+    isOPM: false,
+    label: ["TestLabel"],
+  };
+
+  // PM
+  describe("PM/OPM Validation", () => {
+    it("should return NO errors", () => {
+      const errors = validatePartialRateCompletionPM(
+        [[simpleRate, simpleRate]],
+        undefined,
+        qualifiers,
+        categories
+      );
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should return NO errors - OPM", () => {
+      const errors = validatePartialRateCompletionPM(
+        [],
+        generateOtherPerformanceMeasureData([simpleRate, simpleRate]),
+        qualifiers,
+        categories
+      );
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should have error", () => {
+      const errors = validatePartialRateCompletionPM(
+        [
+          [partialRate, partialRate],
+          [partialRate, partialRate],
+        ],
+        undefined,
+        qualifiers,
+        categories
+      );
+
+      expect(errors).toHaveLength(4);
+      expect(errors[0].errorLocation).toBe("Performance Measure");
+      expect(errors[0].errorMessage).toBe(
+        `Should not have partially filled NDR sets${` at ${qualifiers[0]}`}${`, ${categories[0]}`}.`
+      );
+    });
+
+    it("should have error - OPM", () => {
+      const errors = validatePartialRateCompletionPM(
+        [],
+        generateOtherPerformanceMeasureData([partialRate, partialRate]),
+        qualifiers,
+        categories
+      );
+
+      expect(errors).toHaveLength(6);
+      expect(errors[0].errorLocation).toBe("Other Performance Measure");
+      expect(errors[0].errorMessage).toBe(
+        `Should not have partially filled NDR sets.`
+      );
+    });
+  });
+
+  // OMS
+  describe("OMS Validation", () => {
+    it("should return NO errors", () => {
+      const data = generateOmsCategoryRateData(categories, qualifiers, [
+        simpleRate,
+        simpleRate,
+      ]);
+      const errors = validatePartialRateCompletionOMS({
+        ...baseOMSInfo,
+        rateData: data,
+      });
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should return NO errors - OPM", () => {
+      const data = generateOmsCategoryRateData(categories, qualifiers, [
+        simpleRate,
+        simpleRate,
+      ]);
+      const errors = validatePartialRateCompletionOMS({
+        ...baseOMSInfo,
+        rateData: data,
+        isOPM: true,
+      });
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should have errors", () => {
+      const locationDictionaryJestFunc = jest.fn();
+      const data = generateOmsCategoryRateData(categories, qualifiers, [
+        partialRate,
+        partialRate,
+      ]);
+      const errors = validatePartialRateCompletionOMS({
+        ...baseOMSInfo,
+        locationDictionary: locationDictionaryJestFunc,
+        rateData: data,
+      });
+
+      expect(errors).toHaveLength(4);
+      expect(errors[0].errorLocation).toContain(
+        "Optional Measure Stratification:"
+      );
+      expect(errors[0].errorMessage).toBe(
+        `Should not have partially filled NDR sets${` at ${qualifiers[0]}`}${`, ${categories[0]}`}.`
+      );
+      expect(locationDictionaryJestFunc).toHaveBeenCalledWith(["TestLabel"]);
+    });
+
+    it("should have errors - singleCategory", () => {
+      const locationDictionaryJestFunc = jest.fn();
+      const data = generateOmsCategoryRateData([SINGLE_CATEGORY], qualifiers, [
+        partialRate,
+      ]);
+      const errors = validatePartialRateCompletionOMS({
+        ...baseOMSInfo,
+        locationDictionary: locationDictionaryJestFunc,
+        rateData: data,
+        categories: [SINGLE_CATEGORY],
+      });
+
+      expect(errors).toHaveLength(2);
+      expect(errors[0].errorLocation).toContain(
+        "Optional Measure Stratification:"
+      );
+      expect(errors[0].errorMessage).toBe(
+        `Should not have partially filled NDR sets${` at ${qualifiers[0]}`}.`
+      );
+      expect(locationDictionaryJestFunc).toHaveBeenCalledWith(["TestLabel"]);
+    });
+
+    it("should have errors - OPM", () => {
+      const locationDictionaryJestFunc = jest.fn();
+      const data = generateOmsCategoryRateData(categories, qualifiers, [
+        partialRate,
+        partialRate,
+      ]);
+      const errors = validatePartialRateCompletionOMS({
+        ...baseOMSInfo,
+        locationDictionary: locationDictionaryJestFunc,
+        rateData: data,
+        isOPM: true,
+      });
+
+      expect(errors).toHaveLength(4);
+      expect(errors[0].errorLocation).toContain(
+        "Optional Measure Stratification:"
+      );
+      expect(errors[0].errorMessage).toBe(
+        `Should not have partially filled NDR sets.`
+      );
+      expect(locationDictionaryJestFunc).toHaveBeenCalledWith(["TestLabel"]);
+    });
+  });
+});

--- a/services/ui-src/src/measures/globalValidations/validatePartialRateCompletion/index.ts
+++ b/services/ui-src/src/measures/globalValidations/validatePartialRateCompletion/index.ts
@@ -1,0 +1,83 @@
+import { SINGLE_CATEGORY } from "dataConstants";
+import {
+  convertOmsDataToRateArray,
+  getOtherPerformanceMeasureRateArray,
+} from "../dataDrivenTools";
+import {
+  UnifiedValidationFunction as UVF,
+  FormRateField,
+  OmsValidationCallback,
+} from "../types";
+
+const _validation: UVF = ({ location, rateData, categories, qualifiers }) => {
+  const errors: FormError[] = [];
+
+  for (const [i, rateSet] of rateData.entries()) {
+    for (const [j, rate] of rateSet.entries()) {
+      if (
+        rate &&
+        ((rate.numerator && !rate.denominator) ||
+          (rate.denominator && !rate.numerator))
+      ) {
+        errors.push({
+          errorLocation: location,
+          errorMessage: `Should not have partially filled NDR sets${
+            !!qualifiers?.length ? ` at ${qualifiers[j]}` : ""
+          }${!!categories?.length ? `, ${categories[i]}` : ""}.`,
+        });
+      }
+    }
+  }
+
+  return errors;
+};
+
+export const validatePartialRateCompletionOMS: OmsValidationCallback = ({
+  categories,
+  isOPM,
+  label,
+  locationDictionary,
+  qualifiers,
+  rateData,
+}) => {
+  return [
+    ..._validation({
+      location: `Optional Measure Stratification: ${locationDictionary([
+        ...label,
+      ])}`,
+      rateData: convertOmsDataToRateArray(categories, qualifiers, rateData),
+      categories: !!(isOPM || categories[0] === SINGLE_CATEGORY)
+        ? undefined
+        : categories,
+      qualifiers: !!isOPM ? undefined : qualifiers,
+    }),
+  ];
+};
+
+/**
+ * Checks for fields that have been partially filled out and reports them.
+ *
+ * @param performanceMeasureArray pm data
+ * @param OPM opm data
+ * @param qualifiers required field for parsing PM data
+ * @param categories optional for further locating an error
+ */
+export const validatePartialRateCompletionPM = (
+  performanceMeasureArray: FormRateField[][],
+  OPM: any,
+  qualifiers: string[],
+  categories?: string[]
+) => {
+  return [
+    ..._validation({
+      location: "Performance Measure",
+      rateData: performanceMeasureArray,
+      categories,
+      qualifiers,
+    }),
+    ..._validation({
+      location: "Other Performance Measure",
+      rateData: getOtherPerformanceMeasureRateArray(OPM),
+    }),
+  ];
+};


### PR DESCRIPTION
## Purpose

Add validation for partially filled out NDR sets in both the PM and the OMS sections of forms. This was added to be secondary validations to "Must fill at least one measure" as any that the latter applies to so should the former.

#### Linked Issues to Close

[Ticket to close](https://qmacbis.atlassian.net/browse/OY2-18283?atlOrigin=eyJpIjoiNGVjODVjYzVhMzE3NGJmNThlODdjMWJjODQ4NDBlZTkiLCJwIjoiaiJ9)

## Approach

Validation was made separate in a similar fashion to the other global validations, but instead of being applied to all measures manually, it was added as a function call within the AtLeastOneRateComplete for PM sections and to the omsValidation function for OMS validation. This being fully unit tested, does not change those validations functionality or their coverage. Categories were added to the PM validation this functionality is piggy-backing along to more accurately tell where the error is located.

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
