### PR TITLE
Fix autosave on file upload for Health Home Qualifiers

### DIFF
--- a/services/ui-src/src/views/Qualifiers/HealthHome/costSavingsData.tsx
+++ b/services/ui-src/src/views/Qualifiers/HealthHome/costSavingsData.tsx
@@ -5,11 +5,27 @@ import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "./types";
 import { useParams } from "react-router-dom";
 import { allPositiveIntegersWith10Digits } from "utils/numberInputMasks";
+import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
 
-export const CostSavingsData = () => {
+interface CostSavingsDataProps {
+  handleSave: (data: any) => void;
+}
+
+export const CostSavingsData = ({ handleSave }: CostSavingsDataProps) => {
   const { year }: any = useParams();
   const register = useCustomRegister<Types.CostSavingsData>();
   const padding = "10px";
+  const { watch } = useFormContext();
+
+  useEffect(() => {
+    const subscription = watch((value, { name, type }) => {
+      if (name === "costSavingsFile" && type === "change") {
+        handleSave(value);
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [watch, handleSave]);
   return (
     <CUI.ListItem mr="4">
       <Common.QualifierHeader header="Cost Savings Data" description="" />

--- a/services/ui-src/src/views/Qualifiers/HealthHome/index.tsx
+++ b/services/ui-src/src/views/Qualifiers/HealthHome/index.tsx
@@ -230,7 +230,7 @@ export const HHCSQualifiers = () => {
             </CUI.Box>
             <CUI.OrderedList>
               <AdministrativeQuestions />
-              <CostSavingsData />
+              <CostSavingsData handleSave={handleSave} />
               <DeliverySystems />
               <Common.Audit type="HH" />
               <Common.CompleteCoreSets


### PR DESCRIPTION
## Purpose

https://qmacbis.atlassian.net/browse/OY2-18434

Application endpoint:  https://d2wk89rcvizfao.cloudfront.net/

The function "handleSave" needs to be passed down as a prop so that the upload component in the HH qualifier is able to autosave when a file is uploaded.
 
#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
