### PR TITLE
Allow Date Range to Select Year of current measure (allows 2022)

### DIFF
--- a/services/ui-src/src/components/DateRange/index.tsx
+++ b/services/ui-src/src/components/DateRange/index.tsx
@@ -4,7 +4,6 @@ import { MonthPicker } from "components/MonthPicker";
 import { useFormContext } from "react-hook-form";
 import { format } from "date-fns";
 import { useEffect } from "react";
-import { usePathParams } from "../../hooks/api/usePathParams";
 
 interface Props {
   name: string;
@@ -24,11 +23,10 @@ const RangeNotification = ({ text }: { text: string }) => (
   />
 );
 
+export const currentYear = parseInt(format(new Date(), "yyyy"));
 export const currentMonth = parseInt(format(new Date(), "M"));
 
 export const DateRangeError = ({ name }: { name: string }) => {
-  const { year: selectedYear } = usePathParams();
-  const currentYear = parseInt(selectedYear);
   const { setValue, watch } = useFormContext();
   const range = watch(name);
   const toast = CUI.useToast();

--- a/services/ui-src/src/components/DateRange/index.tsx
+++ b/services/ui-src/src/components/DateRange/index.tsx
@@ -4,6 +4,7 @@ import { MonthPicker } from "components/MonthPicker";
 import { useFormContext } from "react-hook-form";
 import { format } from "date-fns";
 import { useEffect } from "react";
+import { usePathParams } from "../../hooks/api/usePathParams";
 
 interface Props {
   name: string;
@@ -23,10 +24,11 @@ const RangeNotification = ({ text }: { text: string }) => (
   />
 );
 
-export const currentYear = parseInt(format(new Date(), "yyyy"));
 export const currentMonth = parseInt(format(new Date(), "M"));
 
 export const DateRangeError = ({ name }: { name: string }) => {
+  const { year: selectedYear } = usePathParams();
+  const currentYear = parseInt(selectedYear);
   const { setValue, watch } = useFormContext();
   const range = watch(name);
   const toast = CUI.useToast();

--- a/services/ui-src/src/components/MonthPicker/calendarPopup.tsx
+++ b/services/ui-src/src/components/MonthPicker/calendarPopup.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
 import * as CUI from "@chakra-ui/react";
-import config from "config";
 import {
   BsFillCalendar2DateFill,
   BsChevronLeft,
   BsChevronRight,
 } from "react-icons/bs";
+import { usePathParams } from "../../hooks/api/usePathParams";
 
 interface CalendarProps {
   selectedYear?: string;
@@ -33,12 +33,12 @@ const monthNames = [
 
 export const MonthPickerCalendar = ({
   selectedMonth,
-  selectedYear = config.currentReportingYear,
-  maxYear = parseInt(config.currentReportingYear),
-  minYear = parseInt(config.currentReportingYear) - 1,
   yearLocked = false,
   onChange: handleChange,
 }: CalendarProps) => {
+  const { year: selectedYear } = usePathParams();
+  const maxYear = parseInt(selectedYear);
+  const minYear = parseInt(selectedYear) - 1;
   const [pickerOpen, setPickerOpen] = useState(false);
   const [year, setYear] = useState(parseInt(selectedYear) || maxYear);
   const [month, setMonth] = useState(

--- a/services/ui-src/src/components/MonthPicker/calendarPopup.tsx
+++ b/services/ui-src/src/components/MonthPicker/calendarPopup.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from "react";
 import * as CUI from "@chakra-ui/react";
+import config from "config";
 import {
   BsFillCalendar2DateFill,
   BsChevronLeft,
   BsChevronRight,
 } from "react-icons/bs";
-import { usePathParams } from "../../hooks/api/usePathParams";
 
 interface CalendarProps {
+  yearForMeasure?: string;
   selectedYear?: string;
   selectedMonth?: string;
   yearLocked?: boolean;
@@ -32,13 +33,14 @@ const monthNames = [
 ];
 
 export const MonthPickerCalendar = ({
+  yearForMeasure = config.currentReportingYear,
   selectedMonth,
+  selectedYear = yearForMeasure,
+  maxYear = parseInt(yearForMeasure),
+  minYear = parseInt(yearForMeasure) - 1,
   yearLocked = false,
   onChange: handleChange,
 }: CalendarProps) => {
-  const { year: selectedYear } = usePathParams();
-  const maxYear = parseInt(selectedYear);
-  const minYear = parseInt(selectedYear) - 1;
   const [pickerOpen, setPickerOpen] = useState(false);
   const [year, setYear] = useState(parseInt(selectedYear) || maxYear);
   const [month, setMonth] = useState(

--- a/services/ui-src/src/components/MonthPicker/index.tsx
+++ b/services/ui-src/src/components/MonthPicker/index.tsx
@@ -1,6 +1,7 @@
 import * as CUI from "@chakra-ui/react";
 import { MonthPickerCalendar } from "./calendarPopup";
 import { useController, useFormContext } from "react-hook-form";
+import { usePathParams } from "../../hooks/api/usePathParams";
 
 interface CommonProps {
   name: string;
@@ -29,7 +30,7 @@ export const MonthPicker = ({
     name,
     control,
   });
-
+  const { year } = usePathParams();
   const monthRegex = /^((1[0-2])|[1-9])?$/;
   const yearRegex = /^((19|20)?\d{0,2})$/;
 
@@ -80,6 +81,7 @@ export const MonthPicker = ({
               }
             />
             <MonthPickerCalendar
+              yearForMeasure={year}
               yearLocked={yearLocked}
               selectedMonth={field.value?.selectedMonth || initMonth}
               selectedYear={yearLocked ? initYear : field.value?.selectedYear}


### PR DESCRIPTION
## Purpose

https://qmacbis.atlassian.net/browse/OY2-18576

Application endpoint:  https://d3tlh4tt4leyl7.cloudfront.net/

Passed the year as a prop to the calendar popup component so that it may dynamically update depending on the year of 
the measure


#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
