### PR TITLE
Cloudfront S3 Bucket Policy needs to be updated to not give excess permissions to outside accounts

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -108,7 +108,6 @@ resources:
             - Effect: Allow
               Action:
                 - "s3:GetBucketAcl"
-                - "s3:PutBucketAcl"
               Resource: !Sub arn:aws:s3:::${CloudFrontLoggingBucket}
               Principal:
                 CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId


### PR DESCRIPTION
## Purpose
The solution was that we removed put bucket acl permissions that were given to external accounts  

#### Linked Issues to Close
https://qmacbis.atlassian.net/jira/software/c/projects/OY2/boards/208?modal=detail&selectedIssue=OY2-18766

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
