### PR TITLE
OY017992: FFY2022 FUMCH Measure

### DIFF
--- a/services/app-api/handlers/dynamoUtils/measureList.ts
+++ b/services/app-api/handlers/dynamoUtils/measureList.ts
@@ -536,6 +536,10 @@ export const measures: Measure = {
     },
     {
       type: "C",
+      measure: "FUM-CH",
+    },
+    {
+      type: "C",
       measure: "IMA-CH",
     },
     {

--- a/services/ui-src/src/measures/2022/FUMCH/data.ts
+++ b/services/ui-src/src/measures/2022/FUMCH/data.ts
@@ -1,0 +1,19 @@
+import { DataDrivenTypes } from "measures/2021/CommonQuestions/types";
+
+export const qualifiers = ["Ages 6 to 17"];
+export const categories = [
+  "30-day follow-up after ED visit for mental illness",
+  "7-day follow-up after ED visit for mental illness",
+];
+
+export const data: DataDrivenTypes.PerformanceMeasure = {
+  questionText: [
+    "Percentage of emergency department (ED) visits for beneficiaries ages 6 to 17 with a principal diagnosis of mental illness or intentional self-harm and who had a follow-up visit for mental illness. Two rates are reported:",
+  ],
+  questionListItems: [
+    "Percentage of ED visits for mental illness for which the beneficiary received follow-up within 30 days of the ED visit (31 total days)",
+    "Percentage of ED visits for mental illness for which the beneficiary received follow-up within 7 days of the ED visit (8 total days)",
+  ],
+  categories,
+  qualifiers,
+};

--- a/services/ui-src/src/measures/2022/FUMCH/data.ts
+++ b/services/ui-src/src/measures/2022/FUMCH/data.ts
@@ -1,4 +1,4 @@
-import { DataDrivenTypes } from "measures/2021/CommonQuestions/types";
+import { DataDrivenTypes } from "measures/2022/CommonQuestions/types";
 
 export const qualifiers = ["Ages 6 to 17"];
 export const categories = [

--- a/services/ui-src/src/measures/2022/FUMCH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUMCH/index.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
+import * as CMQ from "measures/2021/CommonQuestions";
+import * as PMD from "./data";
+import { validationFunctions } from "./validation";
+import { getPerfMeasureRateArray } from "measures/2021/globalValidations";
+import * as QMR from "components";
+import { FormData } from "./types";
+
+export const FUMCH = ({
+  name,
+  year,
+  measureId,
+  setValidationFunctions,
+  isNotReportingData,
+  isPrimaryMeasureSpecSelected,
+  showOptionalMeasureStrat,
+  isOtherMeasureSpecSelected,
+}: QMR.MeasureWrapperProps) => {
+  const { watch } = useFormContext<FormData>();
+  const data = watch();
+
+  useEffect(() => {
+    if (setValidationFunctions) {
+      setValidationFunctions(validationFunctions);
+    }
+  }, [setValidationFunctions]);
+
+  const performanceMeasureArray = getPerfMeasureRateArray(data, PMD.data);
+
+  return (
+    <>
+      <CMQ.Reporting
+        reportingYear={year}
+        measureName={name}
+        measureAbbreviation={measureId}
+      />
+
+      {!isNotReportingData && (
+        <>
+          <CMQ.StatusOfData />
+          <CMQ.MeasurementSpecification type="HEDIS" />
+          <CMQ.DataSource />
+          <CMQ.DateRange type="child" />
+          <CMQ.DefinitionOfPopulation childMeasure={true} />
+          {isPrimaryMeasureSpecSelected && (
+            <>
+              <CMQ.PerformanceMeasure data={PMD.data} />
+              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+            </>
+          )}
+          {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}
+          <CMQ.CombinedRates />
+          {showOptionalMeasureStrat && (
+            <CMQ.OptionalMeasureStrat
+              performanceMeasureArray={performanceMeasureArray}
+              qualifiers={PMD.qualifiers}
+              categories={PMD.categories}
+              adultMeasure={false}
+            />
+          )}
+        </>
+      )}
+      <CMQ.AdditionalNotes />
+    </>
+  );
+};

--- a/services/ui-src/src/measures/2022/FUMCH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUMCH/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useFormContext } from "react-hook-form";
-import * as CMQ from "measures/2021/CommonQuestions";
+import * as CMQ from "measures/2022/CommonQuestions";
 import * as PMD from "./data";
 import { validationFunctions } from "./validation";
 import { getPerfMeasureRateArray } from "measures/2021/globalValidations";

--- a/services/ui-src/src/measures/2022/FUMCH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUMCH/index.tsx
@@ -3,7 +3,7 @@ import { useFormContext } from "react-hook-form";
 import * as CMQ from "measures/2022/CommonQuestions";
 import * as PMD from "./data";
 import { validationFunctions } from "./validation";
-import { getPerfMeasureRateArray } from "measures/2021/globalValidations";
+import { getPerfMeasureRateArray } from "measures/2022/globalValidations";
 import * as QMR from "components";
 import { FormData } from "./types";
 

--- a/services/ui-src/src/measures/2022/FUMCH/types.ts
+++ b/services/ui-src/src/measures/2022/FUMCH/types.ts
@@ -1,3 +1,3 @@
-import * as Types from "measures/2021/CommonQuestions/types";
+import * as Types from "measures/2022/CommonQuestions/types";
 
 export type FormData = Types.DefaultFormData;

--- a/services/ui-src/src/measures/2022/FUMCH/types.ts
+++ b/services/ui-src/src/measures/2022/FUMCH/types.ts
@@ -1,0 +1,3 @@
+import * as Types from "measures/2021/CommonQuestions/types";
+
+export type FormData = Types.DefaultFormData;

--- a/services/ui-src/src/measures/2022/FUMCH/validation.ts
+++ b/services/ui-src/src/measures/2022/FUMCH/validation.ts
@@ -1,0 +1,97 @@
+import * as DC from "dataConstants";
+import * as GV from "measures/2021/globalValidations";
+import * as PMD from "./data";
+import { FormData } from "./types";
+import { OMSData } from "measures/2021/CommonQuestions/OptionalMeasureStrat/data";
+
+const FUMCHValidation = (data: FormData) => {
+  const ageGroups = PMD.qualifiers;
+  const whyNotReporting = data[DC.WHY_ARE_YOU_NOT_REPORTING];
+  const OPM = data[DC.OPM_RATES];
+  const performanceMeasureArray = GV.getPerfMeasureRateArray(data, PMD.data);
+  const dateRange = data[DC.DATE_RANGE];
+  const deviationArray = GV.getDeviationNDRArray(
+    data.DeviationOptions,
+    data.Deviations,
+    true
+  );
+  const didCalculationsDeviate = data[DC.DID_CALCS_DEVIATE] === DC.YES;
+
+  let errorArray: any[] = [];
+  if (data[DC.DID_REPORT] === DC.NO) {
+    errorArray = [...GV.validateReasonForNotReporting(whyNotReporting)];
+    return errorArray;
+  }
+  let unfilteredSameDenominatorErrors: any[] = [];
+  for (let i = 0; i < performanceMeasureArray.length; i += 2) {
+    unfilteredSameDenominatorErrors = [
+      ...unfilteredSameDenominatorErrors,
+      ...GV.validateEqualQualifierDenominatorsPM(
+        [performanceMeasureArray[i], performanceMeasureArray[i + 1]],
+        ageGroups
+      ),
+    ];
+  }
+
+  let filteredSameDenominatorErrors: any = [];
+  let errorList: string[] = [];
+  unfilteredSameDenominatorErrors.forEach((error) => {
+    if (!(errorList.indexOf(error.errorMessage) > -1)) {
+      errorList.push(error.errorMessage);
+      filteredSameDenominatorErrors.push(error);
+    }
+  });
+
+  errorArray = [
+    ...errorArray,
+    ...GV.validateAtLeastOneRateComplete(
+      performanceMeasureArray,
+      OPM,
+      ageGroups,
+      PMD.categories
+    ),
+    ...GV.validateNumeratorsLessThanDenominatorsPM(
+      performanceMeasureArray,
+      OPM,
+      ageGroups
+    ),
+    ...filteredSameDenominatorErrors,
+    ...GV.validateNoNonZeroNumOrDenomPM(
+      performanceMeasureArray,
+      OPM,
+      ageGroups,
+      data
+    ),
+    ...GV.validateRequiredRadioButtonForCombinedRates(data),
+    ...GV.validateBothDatesCompleted(dateRange),
+    ...GV.validateOneCatRateHigherThanOtherCatPM(data, PMD),
+    ...GV.validateAtLeastOneDataSource(data),
+    ...GV.validateAtLeastOneDeviationFieldFilled(
+      performanceMeasureArray,
+      ageGroups,
+      deviationArray,
+      didCalculationsDeviate
+    ),
+    ...GV.omsValidations({
+      data,
+      qualifiers: PMD.qualifiers,
+      categories: PMD.categories,
+      locationDictionary: GV.omsLocationDictionary(
+        OMSData(true),
+        PMD.qualifiers,
+        PMD.categories
+      ),
+      validationCallbacks: [
+        GV.validateOneCatRateHigherThanOtherCatOMS(),
+        GV.validateNumeratorLessThanDenominatorOMS,
+        GV.validateEqualQualifierDenominatorsOMS,
+        GV.validateRateZeroOMS,
+        GV.validateRateNotZeroOMS,
+      ],
+    }),
+  ];
+
+  return errorArray;
+};
+
+export const validationFunctions = [FUMCHValidation];

--- a/services/ui-src/src/measures/2022/FUMCH/validation.ts
+++ b/services/ui-src/src/measures/2022/FUMCH/validation.ts
@@ -1,8 +1,8 @@
 import * as DC from "dataConstants";
-import * as GV from "measures/2021/globalValidations";
+import * as GV from "measures/2022/globalValidations";
 import * as PMD from "./data";
 import { FormData } from "./types";
-import { OMSData } from "measures/2021/CommonQuestions/OptionalMeasureStrat/data";
+import { OMSData } from "measures/2022/CommonQuestions/OptionalMeasureStrat/data";
 
 const FUMCHValidation = (data: FormData) => {
   const ageGroups = PMD.qualifiers;
@@ -43,7 +43,6 @@ const FUMCHValidation = (data: FormData) => {
   });
 
   errorArray = [
-    ...errorArray,
     ...GV.validateAtLeastOneRateComplete(
       performanceMeasureArray,
       OPM,

--- a/services/ui-src/src/measures/2022/index.tsx
+++ b/services/ui-src/src/measures/2022/index.tsx
@@ -29,6 +29,7 @@ import { DEVCH } from "./DEVCH";
 import { FUAAD } from "./FUAAD";
 import { FUHCH } from "./FUHCH";
 import { FUMAD } from "./FUMAD";
+import { FUMCH } from "./FUMCH";
 import { FVAAD } from "./FVAAD";
 import { HVLAD } from "./HVLAD";
 import { HPCAD } from "./HPCAD";
@@ -85,6 +86,7 @@ const twentyTwentyTwoMeasures = {
   "FUH-AD": FUHAD,
   "FUH-CH": FUHCH,
   "FUM-AD": FUMAD,
+  "FUM-CH": FUMCH,
   "FVA-AD": FVAAD,
   "HVL-AD": HVLAD,
   "HPC-AD": HPCAD,

--- a/services/ui-src/src/measures/measureDescriptions.ts
+++ b/services/ui-src/src/measures/measureDescriptions.ts
@@ -159,6 +159,8 @@ export const measureDescriptions: MeasureList = {
     "DEV-CH": "Developmental Screening in the First Three Years of Life",
     "FUH-CH":
       "Follow-Up After Hospitalization for Mental Illness: Ages 6 to 17",
+    "FUM-CH":
+      "Follow-Up After Emergency Department Visit for Mental Illness: Ages 6 to 17",
     "IMA-CH": "Immunizations for Adolescents",
     "LBW-CH": "Live Births Weighing Less Than 2,500 Grams",
     "LRCD-CH": "Low-Risk Cesarean Delivery",


### PR DESCRIPTION
## Purpose

Adding FUM-CH measure, closes [OY-17992](https://qmacbis.atlassian.net/browse/OY2-17992). 

Application endpoint: [Quality Measure Reporting](https://d1nz3gmcjkjs1v.cloudfront.net/).

#### Linked Issues to Close

Closes OY-17992.

## Approach

Created a new measure.

## Learning

How to create a new measure, how to differentiate between Child, Adult, and Health Home measures in the code.

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
