### PR TITLE
OY-18844: Removing Text from Hybrid Data Source in Measures

### DIFF
--- a/services/ui-src/src/measures/2021/CBPAD/data.ts
+++ b/services/ui-src/src/measures/2021/CBPAD/data.ts
@@ -50,8 +50,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2021/CBPHH/data.ts
+++ b/services/ui-src/src/measures/2021/CBPHH/data.ts
@@ -54,8 +54,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2021/CCSAD/data.ts
+++ b/services/ui-src/src/measures/2021/CCSAD/data.ts
@@ -55,8 +55,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2021/CISCH/data.ts
+++ b/services/ui-src/src/measures/2021/CISCH/data.ts
@@ -76,8 +76,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2021/DEVCH/data.ts
+++ b/services/ui-src/src/measures/2021/DEVCH/data.ts
@@ -54,8 +54,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2021/HPCAD/data.ts
+++ b/services/ui-src/src/measures/2021/HPCAD/data.ts
@@ -50,8 +50,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2021/HPCMIAD/data.ts
+++ b/services/ui-src/src/measures/2021/HPCMIAD/data.ts
@@ -50,8 +50,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2021/IMACH/data.ts
+++ b/services/ui-src/src/measures/2021/IMACH/data.ts
@@ -62,8 +62,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2021/PC01AD/data.ts
+++ b/services/ui-src/src/measures/2021/PC01AD/data.ts
@@ -38,8 +38,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2021/PPCAD/data.ts
+++ b/services/ui-src/src/measures/2021/PPCAD/data.ts
@@ -51,8 +51,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2021/PPCCH/data.ts
+++ b/services/ui-src/src/measures/2021/PPCCH/data.ts
@@ -58,8 +58,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2021/WCCCH/data.ts
+++ b/services/ui-src/src/measures/2021/WCCCH/data.ts
@@ -58,8 +58,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2022/CBPAD/data.ts
+++ b/services/ui-src/src/measures/2022/CBPAD/data.ts
@@ -50,8 +50,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2022/CCSAD/data.ts
+++ b/services/ui-src/src/measures/2022/CCSAD/data.ts
@@ -55,8 +55,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2022/CISCH/data.ts
+++ b/services/ui-src/src/measures/2022/CISCH/data.ts
@@ -76,8 +76,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2022/DEVCH/data.ts
+++ b/services/ui-src/src/measures/2022/DEVCH/data.ts
@@ -54,8 +54,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2022/HPCAD/data.ts
+++ b/services/ui-src/src/measures/2022/HPCAD/data.ts
@@ -50,8 +50,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2022/HPCMIAD/data.ts
+++ b/services/ui-src/src/measures/2022/HPCMIAD/data.ts
@@ -50,8 +50,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2022/IMACH/data.ts
+++ b/services/ui-src/src/measures/2022/IMACH/data.ts
@@ -62,8 +62,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2022/PPCAD/data.ts
+++ b/services/ui-src/src/measures/2022/PPCAD/data.ts
@@ -51,8 +51,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2022/PPCCH/data.ts
+++ b/services/ui-src/src/measures/2022/PPCCH/data.ts
@@ -58,8 +58,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/services/ui-src/src/measures/2022/WCCCH/data.ts
+++ b/services/ui-src/src/measures/2022/WCCCH/data.ts
@@ -58,8 +58,7 @@ export const dataSourceData: DataDrivenTypes.DataSource = {
           ],
         },
         {
-          label:
-            "What is the Medical Records Data Source? (Both can be selected)",
+          label: "What is the Medical Records Data Source?",
           options: [
             {
               value: DC.EHR_DATA,

--- a/tests/cypress/cypress/integration/measures/PPCCH.spec.ts
+++ b/tests/cypress/cypress/integration/measures/PPCCH.spec.ts
@@ -36,11 +36,9 @@ describe("Measure: PPC-CH", () => {
     cy.get(
       '[data-cy="DataSourceSelections.HybridAdministrativeandMedicalRecordsData1.selected0"] > .chakra-checkbox__label > .chakra-text'
     ).should("have.text", "Electronic Health Record (EHR) Data");
-    cy.get(
-      '[data-cy="What is the Medical Records Data Source? (Both can be selected)"]'
-    ).should(
+    cy.get('[data-cy="What is the Medical Records Data Source?"]').should(
       "have.text",
-      "What is the Medical Records Data Source? (Both can be selected)"
+      "What is the Medical Records Data Source?"
     );
     cy.get(
       '[data-cy="DataSourceSelections.HybridAdministrativeandMedicalRecordsData1.selected1"] > .chakra-checkbox__label > .chakra-text'


### PR DESCRIPTION
## Purpose

Currently, the Hybrid data source option has a "Both can be selected" text label, and it is being removed going forward.

Application endpoint:  https://dlkiwhpyyxxmt.cloudfront.net/

#### Linked Issues to Close

Closes [OY-18844](https://qmacbis.atlassian.net/browse/OY2-18844).

## Approach

It's a simple text removal all over the measures.

## Learning

N/A

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
