### PR TITLE
[Oy2-19037] Qualifier Styling Update

### DIFF
--- a/services/ui-src/src/measures/2021/Qualifiers/deliverySystems.tsx
+++ b/services/ui-src/src/measures/2021/Qualifiers/deliverySystems.tsx
@@ -39,7 +39,7 @@ export const DeliverySystems = ({ data, year }: Props) => {
       <CUI.Table variant="simple" mt="4" size="md" verticalAlign="top">
         <CUI.Thead>
           <CUI.Tr>
-            <CUI.Th key="labelRow"></CUI.Th>
+            <CUI.Th key="labelRow" minWidth={"xs"}></CUI.Th>
             {data.textTable.map((textTableArr, index) => {
               return (
                 <CUI.Th

--- a/services/ui-src/src/measures/2022/Qualifiers/deliverySystems.tsx
+++ b/services/ui-src/src/measures/2022/Qualifiers/deliverySystems.tsx
@@ -39,7 +39,7 @@ export const DeliverySystems = ({ data, year }: Props) => {
       <CUI.Table variant="simple" mt="4" size="md" verticalAlign="top">
         <CUI.Thead>
           <CUI.Tr>
-            <CUI.Th key="labelRow"></CUI.Th>
+            <CUI.Th key="labelRow" minWidth={"xs"}></CUI.Th>
             {data.textTable.map((textTableArr, index) => {
               return (
                 <CUI.Th


### PR DESCRIPTION
## Purpose

Add a min-width prop to table heading to ensure text is not truncated.

#### Linked Issues to Close

[Oy2-19037](https://qmacbis.atlassian.net/browse/OY2-19037?atlOrigin=eyJpIjoiNjNjMzVmOTkwYWRkNDA4MDkwNTgwYjdjNGE4MjJjODgiLCJwIjoiaiJ9)

## Approach

Row labels are read-only `QMR.TextInput`s. By extending the column width, the label in question has been made visible. 

Before:
![Screen Shot 2022-06-21 at 11 36 32 AM](https://user-images.githubusercontent.com/22647707/174840970-2b7ebc57-a449-4e30-9209-68aa90754e52.png)

After:
![Screen Shot 2022-06-21 at 11 35 19 AM](https://user-images.githubusercontent.com/22647707/174841005-c5224cfa-be43-4d4e-adfb-95aa2bd14b18.png)

## Assorted Notes/Considerations

The problem with this approach is that an input will never wrap. A long label will always run the risk of being truncated. For those labels that are pre-populated, it might make sense to have these be wrapped by some tag other than input. This would allow us to word-wrap, perhaps be more mobile friendly (terminology used loosely), prevent us from having to potentially update this prop in the future.

Went the CSS route in the interest of affecting as few things as possible. I'm not sure if using this semantic tag affects compliance or it exists for another reason.

#### Pull Request Creator Checklist

- [X] This PR has an associated issue or issues.
- [X] The associated issue(s) are linked above.
- [X] This PR meets all acceptance criteria for those issues.
- [X] This PR and linked issue(s) are adequately documented
- [X] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [X] Someone has been assigned this PR.
- [X] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
