### PR TITLE
[OY2-19133] Missing NDR sets in saved state specific measures

### DIFF
--- a/services/ui-src/src/measures/2021/SSHH/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2021/SSHH/questions/PerformanceMeasure.tsx
@@ -47,7 +47,7 @@ export const PerformanceMeasure = ({
         ],
       });
     }
-  }, [reset]);
+  }, [fields, reset]);
 
   const register = useCustomRegister<Types.OtherPerformanceMeasure>();
 

--- a/services/ui-src/src/measures/2021/SSHH/questions/PerformanceMeasure.tsx
+++ b/services/ui-src/src/measures/2021/SSHH/questions/PerformanceMeasure.tsx
@@ -1,22 +1,14 @@
-import { useFormContext, useForm, useFieldArray } from "react-hook-form";
+import { useFormContext, useFieldArray } from "react-hook-form";
 import * as CUI from "@chakra-ui/react";
 import * as QMR from "components";
 import * as DC from "dataConstants";
 import { useCustomRegister } from "hooks/useCustomRegister";
 import * as Types from "measures/2021/CommonQuestions/types";
+import { useEffect } from "react";
 
 interface Props {
   hybridMeasure?: boolean;
   rateAlwaysEditable?: boolean;
-}
-
-interface ListProps {
-  [DC.DESCRIPTION]: string;
-}
-
-interface FormProps {
-  name: string;
-  [DC.OPM_RATES]: ListProps[];
 }
 
 const stringIsReadOnly = (dataSource: string) => {
@@ -36,22 +28,26 @@ export const PerformanceMeasure = ({
   hybridMeasure,
   rateAlwaysEditable,
 }: Props) => {
-  const { control } = useForm<FormProps>({
-    defaultValues: {
-      name: DC.OPM_RATES,
-      [DC.OPM_RATES]: [
-        {
-          [DC.DESCRIPTION]: "",
-        },
-      ],
-    },
-  });
+  const { control, reset } = useFormContext();
 
   const { fields, remove, append } = useFieldArray({
     name: DC.OPM_RATES,
     control,
     shouldUnregister: true,
   });
+
+  useEffect(() => {
+    if (fields.length === 0) {
+      reset({
+        name: DC.OPM_RATES,
+        [DC.OPM_RATES]: [
+          {
+            [DC.DESCRIPTION]: "",
+          },
+        ],
+      });
+    }
+  }, [reset]);
 
   const register = useCustomRegister<Types.OtherPerformanceMeasure>();
 
@@ -110,6 +106,7 @@ export const PerformanceMeasure = ({
                 <QMR.TextInput
                   label="For example, specify the age groups and whether you are reporting on a certain indicator:"
                   name={`${DC.OPM_RATES}.${index}.${DC.DESCRIPTION}`}
+                  key={`${DC.OPM_RATES}.${index}.${DC.DESCRIPTION}`}
                 />
                 <CUI.Text fontWeight="bold">
                   Enter a number for the numerator and the denominator. Rate
@@ -128,6 +125,7 @@ export const PerformanceMeasure = ({
                     },
                   ]}
                   name={`${DC.OPM_RATES}.${index}.${DC.RATE}`}
+                  key={`${DC.OPM_RATES}.${index}.${DC.RATE}`}
                   readOnly={rateReadOnly}
                 />
               </CUI.Stack>


### PR DESCRIPTION
## Purpose

Ensure all previously-saved performance measures display properly when loading a completed or saved state specific measure.

#### Linked Issues to Close

Resolves [OY2-19133](https://qmacbis.atlassian.net/browse/OY2-19133)

## Approach

Instead of using `useForm()` to populate default values, we switched to `useFormContext()` which has access to the full form data. To create a "blank" default for users creating new state specific measures, we added a `useEffect()` hook that will auto-populate a blank performance measure field set in the same way it did before.

It was also important to add missing `key` values for the description and rate fields.

The result is that state specific measures that have no performance rates will open with an empty NDR set awaiting user input, and for saved state specific measure it will display the saved NDR sets.

## Learning

Each field in a field set requires a unique `key` in addition to `name`. Also, `useFormContext()` has no `defaultValues` option, so it must be set within a `useEffect`.

See [this conversation](https://github.com/react-hook-form/react-hook-form/issues/1870) with the React Hook Forms maintainer for more.

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
