### PR TITLE
Small Sample Size Update

### DIFF
--- a/services/ui-src/src/measures/2021/CommonQuestions/Reporting/index.tsx
+++ b/services/ui-src/src/measures/2021/CommonQuestions/Reporting/index.tsx
@@ -10,6 +10,7 @@ interface Props {
   measureAbbreviation: string;
   reportingYear: string;
   healthHomeMeasure?: boolean;
+  removeLessThan30?: boolean;
 }
 
 export const Reporting = ({
@@ -17,6 +18,7 @@ export const Reporting = ({
   reportingYear,
   measureAbbreviation,
   healthHomeMeasure,
+  removeLessThan30,
 }: Props) => {
   const register = useCustomRegister<Types.DidReport>();
   const { watch } = useFormContext<Types.DidReport>();
@@ -40,7 +42,10 @@ export const Reporting = ({
         />
       </QMR.CoreQuestionWrapper>
       {watchRadioStatus === DC.NO && (
-        <WhyAreYouNotReporting healthHomeMeasure={healthHomeMeasure} />
+        <WhyAreYouNotReporting
+          healthHomeMeasure={healthHomeMeasure}
+          removeLessThan30={removeLessThan30}
+        />
       )}
     </>
   );

--- a/services/ui-src/src/measures/2021/CommonQuestions/WhyAreYouNotReporting/index.tsx
+++ b/services/ui-src/src/measures/2021/CommonQuestions/WhyAreYouNotReporting/index.tsx
@@ -5,9 +5,13 @@ import * as DC from "dataConstants";
 
 interface Props {
   healthHomeMeasure?: boolean;
+  removeLessThan30?: boolean;
 }
 
-export const WhyAreYouNotReporting = ({ healthHomeMeasure }: Props) => {
+export const WhyAreYouNotReporting = ({
+  healthHomeMeasure,
+  removeLessThan30,
+}: Props) => {
   const register = useCustomRegister<Types.WhyAreYouNotReporting>();
   return (
     <QMR.CoreQuestionWrapper label="Why are you not reporting on this measure?">
@@ -168,13 +172,15 @@ export const WhyAreYouNotReporting = ({ healthHomeMeasure }: Props) => {
             ],
           },
           {
-            displayValue: "Small sample size (less than 30)",
+            displayValue: `Small sample size ${
+              removeLessThan30 ? "" : "(less than 30)"
+            }`,
             value: DC.SMALL_SAMPLE_SIZE,
             children: [
               <QMR.NumberInput
                 {...register(DC.SMALL_SAMPLE_SIZE)}
                 label="Enter specific sample size:"
-                mask={/^([1-2]?\d)?$/i}
+                mask={removeLessThan30 ? /^[0-9]*$/i : /^([1-2]?\d)?$/i}
               />,
             ],
           },

--- a/services/ui-src/src/measures/2021/FVAAD/index.tsx
+++ b/services/ui-src/src/measures/2021/FVAAD/index.tsx
@@ -34,6 +34,7 @@ export const FVAAD = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
+        removeLessThan30={true}
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/MSCAD/index.tsx
+++ b/services/ui-src/src/measures/2021/MSCAD/index.tsx
@@ -34,6 +34,7 @@ export const MSCAD = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
+        removeLessThan30={true}
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/PCRAD/index.tsx
+++ b/services/ui-src/src/measures/2021/PCRAD/index.tsx
@@ -35,6 +35,7 @@ export const PCRAD = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
+        removeLessThan30={true}
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2021/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2021/PCRHH/index.tsx
@@ -36,6 +36,7 @@ export const PCRHH = ({
         measureName={name}
         measureAbbreviation={measureId}
         healthHomeMeasure
+        removeLessThan30={true}
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/CommonQuestions/Reporting/index.tsx
+++ b/services/ui-src/src/measures/2022/CommonQuestions/Reporting/index.tsx
@@ -10,6 +10,7 @@ interface Props {
   measureAbbreviation: string;
   reportingYear: string;
   healthHomeMeasure?: boolean;
+  removeLessThan30?: boolean;
 }
 
 export const Reporting = ({
@@ -17,6 +18,7 @@ export const Reporting = ({
   reportingYear,
   measureAbbreviation,
   healthHomeMeasure,
+  removeLessThan30,
 }: Props) => {
   const register = useCustomRegister<Types.DidReport>();
   const { watch } = useFormContext<Types.DidReport>();
@@ -40,7 +42,10 @@ export const Reporting = ({
         />
       </QMR.CoreQuestionWrapper>
       {watchRadioStatus === DC.NO && (
-        <WhyAreYouNotReporting healthHomeMeasure={healthHomeMeasure} />
+        <WhyAreYouNotReporting
+          healthHomeMeasure={healthHomeMeasure}
+          removeLessThan30={removeLessThan30}
+        />
       )}
     </>
   );

--- a/services/ui-src/src/measures/2022/CommonQuestions/WhyAreYouNotReporting/index.tsx
+++ b/services/ui-src/src/measures/2022/CommonQuestions/WhyAreYouNotReporting/index.tsx
@@ -5,9 +5,13 @@ import * as DC from "dataConstants";
 
 interface Props {
   healthHomeMeasure?: boolean;
+  removeLessThan30?: boolean;
 }
 
-export const WhyAreYouNotReporting = ({ healthHomeMeasure }: Props) => {
+export const WhyAreYouNotReporting = ({
+  healthHomeMeasure,
+  removeLessThan30,
+}: Props) => {
   const register = useCustomRegister<Types.WhyAreYouNotReporting>();
   return (
     <QMR.CoreQuestionWrapper label="Why are you not reporting on this measure?">
@@ -168,13 +172,15 @@ export const WhyAreYouNotReporting = ({ healthHomeMeasure }: Props) => {
             ],
           },
           {
-            displayValue: "Small sample size (less than 30)",
+            displayValue: `Small sample size ${
+              removeLessThan30 ? "" : "(less than 30)"
+            }`,
             value: DC.SMALL_SAMPLE_SIZE,
             children: [
               <QMR.NumberInput
                 {...register(DC.SMALL_SAMPLE_SIZE)}
                 label="Enter specific sample size:"
-                mask={/^([1-2]?\d)?$/i}
+                mask={removeLessThan30 ? /^[0-9]*$/i : /^([1-2]?\d)?$/i}
               />,
             ],
           },

--- a/services/ui-src/src/measures/2022/FVAAD/index.tsx
+++ b/services/ui-src/src/measures/2022/FVAAD/index.tsx
@@ -34,6 +34,7 @@ export const FVAAD = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
+        removeLessThan30={true}
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/MSCAD/index.tsx
+++ b/services/ui-src/src/measures/2022/MSCAD/index.tsx
@@ -34,6 +34,7 @@ export const MSCAD = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
+        removeLessThan30={true}
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/PCRAD/index.tsx
+++ b/services/ui-src/src/measures/2022/PCRAD/index.tsx
@@ -35,6 +35,7 @@ export const PCRAD = ({
         reportingYear={year}
         measureName={name}
         measureAbbreviation={measureId}
+        removeLessThan30={true}
       />
 
       {!isNotReportingData && (

--- a/services/ui-src/src/measures/2022/PCRHH/index.tsx
+++ b/services/ui-src/src/measures/2022/PCRHH/index.tsx
@@ -36,6 +36,7 @@ export const PCRHH = ({
         measureName={name}
         measureAbbreviation={measureId}
         healthHomeMeasure
+        removeLessThan30={true}
       />
 
       {!isNotReportingData && (


### PR DESCRIPTION
## Purpose

https://qmacbis.atlassian.net/browse/OY2-19333

Application endpoint:  https://d2tqna38ucv8xv.cloudfront.net/

Less than 30 can now be shown conditionally for all measures and was removed for PCR-AD, PCR-HH, FVA-AD, and MSC-AD. The regex mask for the corresponding number input is also now applied the same way.

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
