### PR TITLE
OY2-19471: Update Total Rate Label for FUA-HH FY2021

### DIFF
--- a/services/ui-src/src/measures/2021/FUAHH/data.ts
+++ b/services/ui-src/src/measures/2021/FUAHH/data.ts
@@ -8,7 +8,7 @@ export const qualifiers = [
   "Ages 13 to 17",
   "Ages 18 to 64",
   "Age 65 and older",
-  "Total",
+  "Total (Age 13 and older)",
 ];
 
 export const data: DataDrivenTypes.PerformanceMeasure = {


### PR DESCRIPTION
## Purpose

To update the Total rate label for the FUA-HH measure to match other rate labels by including explicit age ranges. (i.e. "Total" is now "Total (Age 13 and older)")

Application endpoint: https://d2hxkrw3rc8ueb.cloudfront.net/

#### Linked Issues to Close

Closes [OY2-19471](https://qmacbis.atlassian.net/browse/OY2-19471).

## Approach

Text changes.

## Learning

N/A

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
