### PR TITLE
[OY-19563] Issues with Custom text to validation fields

### DIFF
--- a/services/ui-src/src/measures/2021/AMBCH/index.tsx
+++ b/services/ui-src/src/measures/2021/AMBCH/index.tsx
@@ -54,7 +54,10 @@ export const AMBCH = ({
                 rateScale={rateScale}
                 allowNumeratorGreaterThanDenominator
               />
-              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[4]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && (

--- a/services/ui-src/src/measures/2021/AMRAD/index.tsx
+++ b/services/ui-src/src/measures/2021/AMRAD/index.tsx
@@ -93,7 +93,10 @@ export const AMRAD = ({
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
-              <CMQ.DeviationFromMeasureSpec categories={[]} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={[]}
+                customTotalLabel={PMD.qualifiers[2]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}

--- a/services/ui-src/src/measures/2021/AMRCH/index.tsx
+++ b/services/ui-src/src/measures/2021/AMRCH/index.tsx
@@ -46,7 +46,10 @@ export const AMRCH = ({
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
-              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[2]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}

--- a/services/ui-src/src/measures/2021/APMCH/index.tsx
+++ b/services/ui-src/src/measures/2021/APMCH/index.tsx
@@ -46,7 +46,10 @@ export const APMCH = ({
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
-              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[2]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}

--- a/services/ui-src/src/measures/2021/APPCH/index.tsx
+++ b/services/ui-src/src/measures/2021/APPCH/index.tsx
@@ -46,7 +46,10 @@ export const APPCH = ({
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
-              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[2]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}

--- a/services/ui-src/src/measures/2021/CDFHH/index.tsx
+++ b/services/ui-src/src/measures/2021/CDFHH/index.tsx
@@ -51,7 +51,7 @@ export const CDFHH = ({
                 calcTotal
               />
               <CMQ.DeviationFromMeasureSpec
-                customTotalLabel="Total (Age 12 and older)"
+                customTotalLabel={PMD.qualifiers[3]}
                 categories={PMD.categories}
               />
             </>

--- a/services/ui-src/src/measures/2021/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2021/DEVCH/index.tsx
@@ -48,7 +48,7 @@ export const DEVCH = ({
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />
               <CMQ.DeviationFromMeasureSpec
                 categories={PMD.categories}
-                customTotalLabel="Children"
+                customTotalLabel={PMD.qualifiers[3]}
               />
             </>
           )}

--- a/services/ui-src/src/measures/2021/IETHH/index.tsx
+++ b/services/ui-src/src/measures/2021/IETHH/index.tsx
@@ -47,7 +47,10 @@ export const IETHH = ({
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
-              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[3]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}

--- a/services/ui-src/src/measures/2021/WCVCH/index.tsx
+++ b/services/ui-src/src/measures/2021/WCVCH/index.tsx
@@ -46,7 +46,10 @@ export const WCVCH = ({
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
-              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[3]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}

--- a/services/ui-src/src/measures/2022/AMBCH/index.tsx
+++ b/services/ui-src/src/measures/2022/AMBCH/index.tsx
@@ -54,7 +54,10 @@ export const AMBCH = ({
                 rateScale={rateScale}
                 allowNumeratorGreaterThanDenominator
               />
-              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[4]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && (

--- a/services/ui-src/src/measures/2022/AMRAD/index.tsx
+++ b/services/ui-src/src/measures/2022/AMRAD/index.tsx
@@ -93,7 +93,10 @@ export const AMRAD = ({
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal={true} />
-              <CMQ.DeviationFromMeasureSpec categories={[]} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={[]}
+                customTotalLabel={PMD.qualifiers[2]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}

--- a/services/ui-src/src/measures/2022/AMRCH/index.tsx
+++ b/services/ui-src/src/measures/2022/AMRCH/index.tsx
@@ -46,7 +46,10 @@ export const AMRCH = ({
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
-              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[2]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}

--- a/services/ui-src/src/measures/2022/APMCH/index.tsx
+++ b/services/ui-src/src/measures/2022/APMCH/index.tsx
@@ -46,7 +46,10 @@ export const APMCH = ({
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
-              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[2]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}

--- a/services/ui-src/src/measures/2022/APPCH/index.tsx
+++ b/services/ui-src/src/measures/2022/APPCH/index.tsx
@@ -46,7 +46,10 @@ export const APPCH = ({
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
-              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[2]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}

--- a/services/ui-src/src/measures/2022/CDFHH/index.tsx
+++ b/services/ui-src/src/measures/2022/CDFHH/index.tsx
@@ -51,8 +51,8 @@ export const CDFHH = ({
                 calcTotal
               />
               <CMQ.DeviationFromMeasureSpec
-                customTotalLabel="Total (Age 12 and older)"
                 categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[3]}
               />
             </>
           )}

--- a/services/ui-src/src/measures/2022/DEVCH/index.tsx
+++ b/services/ui-src/src/measures/2022/DEVCH/index.tsx
@@ -48,7 +48,7 @@ export const DEVCH = ({
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal hybridMeasure />
               <CMQ.DeviationFromMeasureSpec
                 categories={PMD.categories}
-                customTotalLabel="Children"
+                customTotalLabel={PMD.qualifiers[3]}
               />
             </>
           )}

--- a/services/ui-src/src/measures/2022/FUMHH/index.tsx
+++ b/services/ui-src/src/measures/2022/FUMHH/index.tsx
@@ -47,7 +47,10 @@ export const FUMHH = ({
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure calcTotal data={PMD.data} />
-              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[3]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && (

--- a/services/ui-src/src/measures/2022/IETHH/index.tsx
+++ b/services/ui-src/src/measures/2022/IETHH/index.tsx
@@ -47,7 +47,10 @@ export const IETHH = ({
           {isPrimaryMeasureSpecSelected && (
             <>
               <CMQ.PerformanceMeasure data={PMD.data} calcTotal />
-              <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
+              <CMQ.DeviationFromMeasureSpec
+                categories={PMD.categories}
+                customTotalLabel={PMD.qualifiers[3]}
+              />
             </>
           )}
           {isOtherMeasureSpecSelected && <CMQ.OtherPerformanceMeasure />}


### PR DESCRIPTION
## Purpose

Some measures did not have the correct custom label set for totals in the `DeviationFromMeasureSpec` component. I kept the method for retrieving the custom label consistent with what was already there by accessing the correct custom label from `PMD.qualifiers`.

#### Linked Issues to Close

Closes [OY-19563](https://qmacbis.atlassian.net/browse/OY2-19563).

## Approach

The custom total label can exist in the `PMD.qualifiers` array from a measure's corresponding `data.ts` file. Not all measures have a custom total label, but those that do include it as the last item in this array.

One of the existing measures accesses this label using this method: `PMD.qualifiers.slice(-1)[0]`, which I have left in place because it works fine. However, other measures accessed the item directly, i.e. `PMD.qualifiers[3]`. Because more measures used this method than the first method, this is the method I chose for measures that were missing this label altogether in order to keep things as consistent as possible.

Adding this label to `DeviationFromMeasureSpec` also adds it to corresponding validation warnings.

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
