### PR TITLE
MDCT-496: Update Denominator Medicare/Medicaid Dually Eligibles Validation Message

### DIFF
--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -479,7 +479,7 @@ export const MeasureWrapper = ({
                       alertProps={{ my: "3" }}
                       alertStatus="error"
                       alertTitle={` ${error.errorLocation} ${
-                        error.errorType ? error.errorType : " Error"
+                        error.errorType ? error.errorType : "Error"
                       }`}
                       alertDescription={error.errorMessage}
                       extendedAlertList={error.errorList}

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -477,6 +477,7 @@ export const MeasureWrapper = ({
                     <QMR.Notification
                       key={uuidv4()}
                       alertProps={{ my: "3" }}
+                      // If there is an error type, default to Warning
                       alertStatus={error.errorType ? "warning" : "error"}
                       alertTitle={`${error.errorLocation} ${
                         error.errorType ?? "Error"

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -478,7 +478,7 @@ export const MeasureWrapper = ({
                       key={uuidv4()}
                       alertProps={{ my: "3" }}
                       alertStatus={error.errorType ? "warning" : "error"}
-                      alertTitle={` ${error.errorLocation} ${
+                      alertTitle={`${error.errorLocation} ${
                         error.errorType ?? "Error"
                       }`}
                       alertDescription={error.errorMessage}

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -478,10 +478,9 @@ export const MeasureWrapper = ({
                       key={uuidv4()}
                       alertProps={{ my: "3" }}
                       alertStatus="error"
-                      alertTitle={
-                        error.errorLocation +
-                        `${error.errorType ? error.errorType : " Error"}`
-                      }
+                      alertTitle={` ${error.errorLocation} ${
+                        error.errorType ? error.errorType : " Error"
+                      }`}
                       alertDescription={error.errorMessage}
                       extendedAlertList={error.errorList}
                       close={() => {

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -478,7 +478,10 @@ export const MeasureWrapper = ({
                       key={uuidv4()}
                       alertProps={{ my: "3" }}
                       alertStatus="error"
-                      alertTitle={`${error.errorLocation} Error`}
+                      alertTitle={
+                        error.errorLocation +
+                        `${error.errorType ? error.errorType : " Error"}`
+                      }
                       alertDescription={error.errorMessage}
                       extendedAlertList={error.errorList}
                       close={() => {

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -477,7 +477,7 @@ export const MeasureWrapper = ({
                     <QMR.Notification
                       key={uuidv4()}
                       alertProps={{ my: "3" }}
-                      alertStatus="error"
+                      alertStatus={error.errorType ? "warning" : "error"}
                       alertTitle={` ${error.errorLocation} ${
                         error.errorType ?? "Error"
                       }`}

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -479,7 +479,7 @@ export const MeasureWrapper = ({
                       alertProps={{ my: "3" }}
                       alertStatus="error"
                       alertTitle={` ${error.errorLocation} ${
-                        error.errorType ? error.errorType : "Error"
+                        error.errorType ?? "Error"
                       }`}
                       alertDescription={error.errorMessage}
                       extendedAlertList={error.errorList}

--- a/services/ui-src/src/error.d.ts
+++ b/services/ui-src/src/error.d.ts
@@ -1,7 +1,7 @@
 interface FormError {
   errorLocation: string;
-  errorType?: string;
   errorMessage: string;
+  errorType?: string;
   errorList?: string[];
 }
 

--- a/services/ui-src/src/error.d.ts
+++ b/services/ui-src/src/error.d.ts
@@ -1,5 +1,6 @@
 interface FormError {
   errorLocation: string;
+  errorType?: string;
   errorMessage: string;
   errorList?: string[];
 }

--- a/services/ui-src/src/measures/2021/globalValidations/validateDualPopInformation/index.ts
+++ b/services/ui-src/src/measures/2021/globalValidations/validateDualPopInformation/index.ts
@@ -48,14 +48,14 @@ export const validateDualPopInformationPM = (
     errorArray.push({
       errorLocation: "Performance Measure",
       errorMessage: errorMessageFunc(dualEligible, errorReplacementText),
-      errorType: " Warning",
+      errorType: "Warning",
     });
   }
   if (dualEligible && filledInData.length === 0) {
     errorArray.push({
       errorLocation: "Performance Measure",
       errorMessage: errorMessageFunc(dualEligible, errorReplacementText),
-      errorType: " Warning",
+      errorType: "Warning",
     });
   }
   return errorArray;

--- a/services/ui-src/src/measures/2021/globalValidations/validateDualPopInformation/index.ts
+++ b/services/ui-src/src/measures/2021/globalValidations/validateDualPopInformation/index.ts
@@ -48,12 +48,14 @@ export const validateDualPopInformationPM = (
     errorArray.push({
       errorLocation: "Performance Measure",
       errorMessage: errorMessageFunc(dualEligible, errorReplacementText),
+      errorType: " Warning",
     });
   }
   if (dualEligible && filledInData.length === 0) {
     errorArray.push({
       errorLocation: "Performance Measure",
       errorMessage: errorMessageFunc(dualEligible, errorReplacementText),
+      errorType: " Warning",
     });
   }
   return errorArray;

--- a/services/ui-src/src/measures/2022/globalValidations/validateDualPopInformation/index.ts
+++ b/services/ui-src/src/measures/2022/globalValidations/validateDualPopInformation/index.ts
@@ -48,12 +48,14 @@ export const validateDualPopInformationPM = (
     errorArray.push({
       errorLocation: "Performance Measure",
       errorMessage: errorMessageFunc(dualEligible, errorReplacementText),
+      errorType: "Warning",
     });
   }
   if (dualEligible && filledInData.length === 0) {
     errorArray.push({
       errorLocation: "Performance Measure",
       errorMessage: errorMessageFunc(dualEligible, errorReplacementText),
+      errorType: "Warning",
     });
   }
   return errorArray;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3345,9 +3345,9 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001349:
-  version "1.0.30001352"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz#cc6f5da3f983979ad1e2cdbae0505dccaa7c6a12"
-  integrity sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA==
+  version "1.0.30001370"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz"
+  integrity sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Purpose

To update the validation message for "Definition of Denominator Medicare/Medicaid Dually Eligibles" from an error to a warning.

Application endpoint: https://dza09tz3b992g.cloudfront.net/

#### Linked Issues to Close

Closes [MDCT-496](https://qmacbis.atlassian.net/browse/MDCT-496).

## Approach

There's an optional field for error types, if there needs to be a "Warning" or another custom field as opposed to "Error", that can now be done.

## Learning

Went on a TypeScript rabbit hole.

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
