### PR TITLE
COMP: Updated 2022 measuers

### DIFF
--- a/services/ui-src/src/measures/2022/SFMCH/index.tsx
+++ b/services/ui-src/src/measures/2022/SFMCH/index.tsx
@@ -45,7 +45,7 @@ export const SFMCH = ({
           <CMQ.DefinitionOfPopulation childMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
-              <CMQ.PerformanceMeasure data={PMD.data} showtextbox={false} />
+              <CMQ.PerformanceMeasure data={PMD.data} showtextbox={true} />
               <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
             </>
           )}

--- a/services/ui-src/src/measures/2022/W30CH/index.tsx
+++ b/services/ui-src/src/measures/2022/W30CH/index.tsx
@@ -45,7 +45,7 @@ export const W30CH = ({
           <CMQ.DefinitionOfPopulation childMeasure />
           {isPrimaryMeasureSpecSelected && (
             <>
-              <CMQ.PerformanceMeasure data={PMD.data} showtextbox={false} />
+              <CMQ.PerformanceMeasure data={PMD.data} showtextbox={true} />
               <CMQ.DeviationFromMeasureSpec categories={PMD.categories} />
             </>
           )}


### PR DESCRIPTION
## Purpose

Adds text box to specified performance measures 

#### Linked Issues to Close

[https://qmacbis.atlassian.net/browse/MDCT-1821](https://qmacbis.atlassian.net/browse/MDCT-1821)

## Approach

It adds the text box

## Learning

I learned the things to complete the ticket

## Assorted Notes/Considerations

If this is a thing that happens for all measures in their second year+ it might be worth looking into if we can automate this flag vs manually setting it each year

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
