### PR TITLE
MDCT-496: Update Denominator Medicare/Medicaid Dually Eligibles Validation Message

### DIFF
--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -477,8 +477,10 @@ export const MeasureWrapper = ({
                     <QMR.Notification
                       key={uuidv4()}
                       alertProps={{ my: "3" }}
-                      alertStatus="error"
-                      alertTitle={`${error.errorLocation} Error`}
+                      alertStatus={error.errorType ? "warning" : "error"}
+                      alertTitle={`${error.errorLocation} ${
+                        error.errorType ?? "Error"
+                      }`}
                       alertDescription={error.errorMessage}
                       extendedAlertList={error.errorList}
                       close={() => {

--- a/services/ui-src/src/error.d.ts
+++ b/services/ui-src/src/error.d.ts
@@ -1,6 +1,7 @@
 interface FormError {
   errorLocation: string;
   errorMessage: string;
+  errorType?: string;
   errorList?: string[];
 }
 

--- a/services/ui-src/src/measures/2021/globalValidations/ComplexValidations/ComplexValidateDualPopInformation/index.tsx
+++ b/services/ui-src/src/measures/2021/globalValidations/ComplexValidations/ComplexValidateDualPopInformation/index.tsx
@@ -46,6 +46,7 @@ export const ComplexValidateDualPopInformation = (
     errorArray.push({
       errorLocation: "Performance Measure",
       errorMessage: `Information has been included in the ${errorReplacementText} Performance Measure but the checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is missing`,
+      errorType: "Warning",
     });
   }
   if (dualEligible && filledInData.length === 0) {

--- a/services/ui-src/src/measures/2021/globalValidations/validateDualPopInformation/index.ts
+++ b/services/ui-src/src/measures/2021/globalValidations/validateDualPopInformation/index.ts
@@ -48,6 +48,7 @@ export const validateDualPopInformationPM = (
     errorArray.push({
       errorLocation: "Performance Measure",
       errorMessage: errorMessageFunc(dualEligible, errorReplacementText),
+      errorType: "Warning",
     });
   }
   if (dualEligible && filledInData.length === 0) {

--- a/services/ui-src/src/measures/2022/globalValidations/ComplexValidations/ComplexValidateDualPopInformation/index.tsx
+++ b/services/ui-src/src/measures/2022/globalValidations/ComplexValidations/ComplexValidateDualPopInformation/index.tsx
@@ -46,6 +46,7 @@ export const ComplexValidateDualPopInformation = (
     errorArray.push({
       errorLocation: "Performance Measure",
       errorMessage: `Information has been included in the ${errorReplacementText} Performance Measure but the checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is missing`,
+      errorType: "Warning",
     });
   }
   if (dualEligible && filledInData.length === 0) {

--- a/services/ui-src/src/measures/2022/globalValidations/validateDualPopInformation/index.ts
+++ b/services/ui-src/src/measures/2022/globalValidations/validateDualPopInformation/index.ts
@@ -48,6 +48,7 @@ export const validateDualPopInformationPM = (
     errorArray.push({
       errorLocation: "Performance Measure",
       errorMessage: errorMessageFunc(dualEligible, errorReplacementText),
+      errorType: "Warning",
     });
   }
   if (dualEligible && filledInData.length === 0) {


### PR DESCRIPTION
## Purpose

To update the validation message for "Definition of Denominator Medicare/Medicaid Dually Eligibles" from an error to a warning.

**Note:** This is a duplicate PR, the other branch was having issues.

Application endpoint: https://d2i6sdy4antu38.cloudfront.net/

#### Linked Issues to Close

Closes [MDCT-496](https://qmacbis.atlassian.net/browse/MDCT-496).

## Learning

There's an optional field for error types, if there needs to be a "Warning" or another custom field as opposed to "Error", that can now be done.

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
