### PR TITLE
Mdct 490 cloudfront logs

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -114,21 +114,10 @@ resources:
           Version: "2012-10-17"
           Statement:
             - Effect: Allow
-              Action: "s3:GetBucketAcl"
-              Resource: !Sub arn:aws:s3:::${CloudFrontLoggingBucket}
+              Action: "s3:PutObject"
+              Resource: !Sub arn:aws:s3:::${LoggingBucket}/*
               Principal:
-                CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
-              Condition:
-                Bool:
-                  "aws:SecureTransport": true
-            - Action:
-                - "s3:*"
-              Effect: "Deny"
-              Principal: "*"
-              Resource: !Sub arn:aws:s3:::${CloudFrontLoggingBucket}
-              Condition:
-                Bool:
-                  "aws:SecureTransport": false
+                AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
         Bucket: !Ref CloudFrontLoggingBucket
     CloudFrontWebAcl:
       Type: AWS::WAFv2::WebACL
@@ -208,6 +197,9 @@ resources:
               ResponseCode: 403
               ResponsePagePath: /index.html
           WebACLId: !GetAtt CloudFrontWebAcl.Arn
+          Logging:
+            Bucket: !Sub "${CloudFrontLoggingBucket}.s3.amazonaws.com"
+            Prefix: AWSLogs/CLOUDFRONT/${self:custom.stage}/
     Route53DnsRecord:
       Type: AWS::Route53::RecordSet
       Condition: CreateDnsRecord

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -80,6 +80,11 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: !Sub ${AWS::AccountId}-${self:service}-${self:custom.stage}-cloudfront-logs
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
         BucketEncryption:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
@@ -118,6 +123,16 @@ resources:
               Resource: !Sub arn:aws:s3:::${CloudFrontLoggingBucket}/*
               Principal:
                 AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            - Sid: "AllowSSLRequestsOnly"
+              Effect: Deny
+              Action: "s3:*"
+              Principal: "*"
+              Resource:
+                - !Sub arn:aws:s3:::${CloudFrontLoggingBucket}/*
+                - !Sub arn:aws:s3:::${CloudFrontLoggingBucket}
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
         Bucket: !Ref CloudFrontLoggingBucket
     CloudFrontWebAcl:
       Type: AWS::WAFv2::WebACL

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -115,7 +115,7 @@ resources:
           Statement:
             - Effect: Allow
               Action: "s3:PutObject"
-              Resource: !Sub arn:aws:s3:::${LoggingBucket}/*
+              Resource: !Sub arn:aws:s3:::${CloudFrontLoggingBucket}/*
               Principal:
                 AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
         Bucket: !Ref CloudFrontLoggingBucket


### PR DESCRIPTION
## Purpose

Enable cloudfront logs. The bucket was already there, just didn't have it hooked up to the cloudfront distribution with the right permissions.

[MDCT-490](https://qmacbis.atlassian.net/browse/MDCT-490)

## How to test
View this bucket `024259748323-ui-mdct-490-cloudfront-logs-cloudfront-logs` in qmr dev. It has logs!

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
