### PR TITLE
Mdct 1842 pt. 1 File upload security

### DIFF
--- a/services/ui-src/src/components/Upload/index.tsx
+++ b/services/ui-src/src/components/Upload/index.tsx
@@ -146,11 +146,24 @@ export const Upload = ({
     field.onChange(filteredArray);
   };
 
+  function fileNameValidator(file: any) {
+    const fileNameRegex = new RegExp("^[0-9a-zA-z-_.()*]*$");
+
+    if (!fileNameRegex.test(file.name)) {
+      return {
+        code: "Invalid file name",
+        message: `The file name contains invalid characters. Only the following characters are allowed: A-Z, a-z, 0-9, -, _, (, ), *, and .`,
+      };
+    }
+    return null;
+  }
+
   const { getRootProps, getInputProps, isDragActive, fileRejections } =
     useDropzone({
       onDrop,
       accept: acceptedFileTypes,
       maxSize,
+      validator: fileNameValidator,
     });
 
   function ensureLowerCaseFileExtension(file: any) {

--- a/services/uploads/src/antivirus.js
+++ b/services/uploads/src/antivirus.js
@@ -5,6 +5,7 @@
 const AWS = require("aws-sdk");
 const path = require("path");
 const fs = require("fs");
+const crypto = require("crypto");
 const clamav = require("./clamav");
 const s3 = new AWS.S3();
 const utils = require("./utils");
@@ -44,11 +45,11 @@ async function isS3FileTooBig(s3ObjectKey, s3ObjectBucket) {
 }
 
 function downloadFileFromS3(s3ObjectKey, s3ObjectBucket) {
-  const downloadDir = `/tmp/download`;
-  if (!fs.existsSync(downloadDir)) {
-    fs.mkdirSync(downloadDir);
+  if (!fs.existsSync(constants.TMP_DOWNLOAD_PATH)) {
+    fs.mkdirSync(constants.TMP_DOWNLOAD_PATH);
   }
-  let localPath = `${downloadDir}/${path.basename(s3ObjectKey)}`;
+  const tmpFileName = `${crypto.randomUUID()}.tmp`;
+  let localPath = `${constants.TMP_DOWNLOAD_PATH}${tmpFileName}`;
 
   let writeStream = fs.createWriteStream(localPath);
 
@@ -68,7 +69,7 @@ function downloadFileFromS3(s3ObjectKey, s3ObjectBucket) {
         utils.generateSystemMessage(
           `Finished downloading new object ${s3ObjectKey}`
         );
-        resolve();
+        resolve(localPath);
       })
       .on("error", function (err) {
         console.log(err);
@@ -124,9 +125,9 @@ async function lambdaHandleEvent(event, context) {
       constants.PATH_TO_AV_DEFINITIONS
     );
     utils.generateSystemMessage("Download File from S3");
-    await downloadFileFromS3(s3ObjectKey, s3ObjectBucket);
+    const filePath = await downloadFileFromS3(s3ObjectKey, s3ObjectBucket);
     utils.generateSystemMessage("Set virusScanStatus");
-    virusScanStatus = clamav.scanLocalFile(path.basename(s3ObjectKey));
+    virusScanStatus = clamav.scanLocalFile(filePath);
     utils.generateSystemMessage(`virusScanStatus=${virusScanStatus}`);
   }
 

--- a/services/uploads/src/antivirus.js
+++ b/services/uploads/src/antivirus.js
@@ -5,7 +5,6 @@
 const AWS = require("aws-sdk");
 const path = require("path");
 const fs = require("fs");
-const crypto = require("crypto");
 const clamav = require("./clamav");
 const s3 = new AWS.S3();
 const utils = require("./utils");
@@ -18,15 +17,8 @@ const constants = require("./constants");
  * @return {int} Length of S3 object in bytes.
  */
 async function sizeOf(key, bucket) {
-  console.log("key: " + key);
-  console.log("bucket: " + bucket);
-
-  try {
-    let res = await s3.headObject({ Key: key, Bucket: bucket }).promise();
-    return res.ContentLength;
-  } catch (err) {
-    console.log("sizeOf error:" + err);
-  }
+  let res = await s3.headObject({ Key: key, Bucket: bucket }).promise();
+  return res.ContentLength;
 }
 
 /**
@@ -36,21 +28,30 @@ async function sizeOf(key, bucket) {
  * @return {boolean} True if S3 object is larger then MAX_FILE_SIZE
  */
 async function isS3FileTooBig(s3ObjectKey, s3ObjectBucket) {
-  try {
-    let fileSize = await sizeOf(s3ObjectKey, s3ObjectBucket);
-    return fileSize > constants.MAX_FILE_SIZE;
-  } catch (err) {
-    console.log("isS3FileTooBig error:" + err);
-  }
+  let fileSize = await sizeOf(s3ObjectKey, s3ObjectBucket);
+  return fileSize > constants.MAX_FILE_SIZE;
+}
+
+const downloadDir = constants.DOWNLOAD_DIR;
+
+/**
+ * Returns the /tmp local path from an s3ObjectKey
+ * @param {string} s3ObjectKey Key of the s3 object
+ * @return {string} Path of the s3 object on the local fs
+ *
+ */
+function pathFromObjectKey(s3ObjectKey) {
+  // remove problematic characters from filename
+  let sanitizedFilename = s3ObjectKey.replace(/[^a-zA-Z0-9]/g, "");
+  return `${downloadDir}/${path.basename(sanitizedFilename)}`;
 }
 
 function downloadFileFromS3(s3ObjectKey, s3ObjectBucket) {
-  if (!fs.existsSync(constants.TMP_DOWNLOAD_PATH)) {
-    fs.mkdirSync(constants.TMP_DOWNLOAD_PATH);
+  if (!fs.existsSync(downloadDir)) {
+    fs.mkdirSync(downloadDir);
   }
-  const tmpFileName = `${crypto.randomUUID()}.tmp`;
-  let localPath = `${constants.TMP_DOWNLOAD_PATH}${tmpFileName}`;
 
+  let localPath = pathFromObjectKey(s3ObjectKey);
   let writeStream = fs.createWriteStream(localPath);
 
   utils.generateSystemMessage(
@@ -69,17 +70,17 @@ function downloadFileFromS3(s3ObjectKey, s3ObjectBucket) {
         utils.generateSystemMessage(
           `Finished downloading new object ${s3ObjectKey}`
         );
-        resolve(localPath);
+        resolve();
       })
       .on("error", function (err) {
-        console.log(err);
+        console.log(err); // eslint-disable-line no-console
         reject();
       })
       .pipe(writeStream);
   });
 }
 
-async function lambdaHandleEvent(event, context) {
+async function lambdaHandleEvent(event, _context) {
   utils.generateSystemMessage("Start Antivirus Lambda function");
 
   let s3ObjectKey = utils.extractKeyFromS3Event(event);
@@ -91,27 +92,10 @@ async function lambdaHandleEvent(event, context) {
 
   let virusScanStatus;
 
-  try {
-    await s3
-      .putObjectTagging({
-        Bucket: s3ObjectBucket,
-        Key: s3ObjectKey,
-        Tagging: {
-          TagSet: [
-            {
-              Key: constants.VIRUS_STATUS_STATUS_KEY,
-              Value: "PENDING",
-            },
-          ],
-        },
-      })
-      .promise();
-  } catch (e) {
-    console.log(e);
-  }
-
-  //You need to verify that you are not getting too large a file
-  //currently lambdas max out at 500MB storage.
+  /*
+   * You need to verify that you are not getting too large a file
+   * currently lambdas max out at 500MB storage.
+   */
   if (await isS3FileTooBig(s3ObjectKey, s3ObjectBucket)) {
     virusScanStatus = constants.STATUS_SKIPPED_FILE;
     utils.generateSystemMessage(
@@ -125,8 +109,9 @@ async function lambdaHandleEvent(event, context) {
       constants.PATH_TO_AV_DEFINITIONS
     );
     utils.generateSystemMessage("Download File from S3");
-    const filePath = await downloadFileFromS3(s3ObjectKey, s3ObjectBucket);
+    await downloadFileFromS3(s3ObjectKey, s3ObjectBucket);
     utils.generateSystemMessage("Set virusScanStatus");
+    let filePath = pathFromObjectKey(s3ObjectKey);
     virusScanStatus = clamav.scanLocalFile(filePath);
     utils.generateSystemMessage(`virusScanStatus=${virusScanStatus}`);
   }
@@ -141,9 +126,9 @@ async function lambdaHandleEvent(event, context) {
     await s3.putObjectTagging(taggingParams).promise();
     utils.generateSystemMessage("Tagging successful");
   } catch (err) {
-    console.log(err);
+    console.log(err); // eslint-disable-line no-console
   } finally {
-    return virusScanStatus;
+    return virusScanStatus; // eslint-disable-line no-unsafe-finally
   }
 }
 
@@ -167,9 +152,9 @@ async function scanS3Object(s3ObjectKey, s3ObjectBucket) {
     await s3.putObjectTagging(taggingParams).promise();
     utils.generateSystemMessage("Tagging successful");
   } catch (err) {
-    console.log(err);
+    console.log(err); // eslint-disable-line no-console
   } finally {
-    return virusScanStatus;
+    return virusScanStatus; // eslint-disable-line no-unsafe-finally
   }
 }
 

--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -192,7 +192,7 @@ async function uploadAVDefinitions() {
  * @param pathToFile Path in the filesystem where the file is stored.
  */
 function scanLocalFile(pathToFile) {
-  let downloadDir = constants.TMP_DOWNLOAD_PATH;
+  let downloadDir = constants.DOWNLOAD_DIR;
   try {
     let avResult = spawnSync(constants.PATH_TO_CLAMAV, [
       "--stdout",

--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -1,6 +1,6 @@
 const AWS = require("aws-sdk");
 const fs = require("fs");
-const execSync = require("child_process").execSync;
+const spawnSync = require("child_process").spawnSync;
 const path = require("path");
 const constants = require("./constants");
 const utils = require("./utils");
@@ -34,7 +34,7 @@ async function listBucketFiles(bucketName) {
  */
 function updateAVDefinitonsWithFreshclam() {
   try {
-    let executionResult = execSync(
+    let executionResult = spawnSync(
       `${constants.PATH_TO_FRESHCLAM} --config-file=${constants.FRESHCLAM_CONFIG} --datadir=${constants.FRESHCLAM_WORK_DIR}`
     );
 
@@ -192,10 +192,15 @@ async function uploadAVDefinitions() {
  * @param pathToFile Path in the filesystem where the file is stored.
  */
 function scanLocalFile(pathToFile) {
+  let downloadDir = constants.TMP_DOWNLOAD_PATH;
   try {
-    let avResult = execSync(
-      `${constants.PATH_TO_CLAMAV} -v -a --stdout -d /tmp/download/${pathToFile}`
-    );
+    let avResult = spawnSync(constants.PATH_TO_CLAMAV, [
+      "--stdout",
+      "-v",
+      "-a",
+      "-d",
+      `${downloadDir}${pathToFile}`,
+    ]);
 
     utils.generateSystemMessage("SUCCESSFUL SCAN, FILE CLEAN");
     console.log(avResult.toString());

--- a/services/uploads/src/constants.js
+++ b/services/uploads/src/constants.js
@@ -22,6 +22,7 @@ const PATH_TO_FRESHCLAM = "/opt/bin/freshclam";
 const PATH_TO_CLAMAV = "/opt/bin/clamscan";
 const FRESHCLAM_CONFIG = "/opt/bin/freshclam.conf";
 const FRESHCLAM_WORK_DIR = "/tmp/";
+const TMP_DOWNLOAD_PATH = "/tmp/download/";
 
 // Constants for tagging file after a virus scan.
 const STATUS_CLEAN_FILE = process.env.STATUS_CLEAN_FILE || "CLEAN";
@@ -44,6 +45,7 @@ module.exports = {
   PATH_TO_CLAMAV: PATH_TO_CLAMAV,
   FRESHCLAM_CONFIG: FRESHCLAM_CONFIG,
   FRESHCLAM_WORK_DIR: FRESHCLAM_WORK_DIR,
+  TMP_DOWNLOAD_PATH: TMP_DOWNLOAD_PATH,
   STATUS_CLEAN_FILE: STATUS_CLEAN_FILE,
   STATUS_INFECTED_FILE: STATUS_INFECTED_FILE,
   STATUS_ERROR_PROCESSING_FILE: STATUS_ERROR_PROCESSING_FILE,

--- a/services/uploads/src/constants.js
+++ b/services/uploads/src/constants.js
@@ -22,7 +22,7 @@ const PATH_TO_FRESHCLAM = "/opt/bin/freshclam";
 const PATH_TO_CLAMAV = "/opt/bin/clamscan";
 const FRESHCLAM_CONFIG = "/opt/bin/freshclam.conf";
 const FRESHCLAM_WORK_DIR = "/tmp/";
-const TMP_DOWNLOAD_PATH = "/tmp/download/";
+const DOWNLOAD_DIR = "/tmp/download/";
 
 // Constants for tagging file after a virus scan.
 const STATUS_CLEAN_FILE = process.env.STATUS_CLEAN_FILE || "CLEAN";
@@ -45,7 +45,7 @@ module.exports = {
   PATH_TO_CLAMAV: PATH_TO_CLAMAV,
   FRESHCLAM_CONFIG: FRESHCLAM_CONFIG,
   FRESHCLAM_WORK_DIR: FRESHCLAM_WORK_DIR,
-  TMP_DOWNLOAD_PATH: TMP_DOWNLOAD_PATH,
+  DOWNLOAD_DIR: DOWNLOAD_DIR,
   STATUS_CLEAN_FILE: STATUS_CLEAN_FILE,
   STATUS_INFECTED_FILE: STATUS_INFECTED_FILE,
   STATUS_ERROR_PROCESSING_FILE: STATUS_ERROR_PROCESSING_FILE,


### PR DESCRIPTION
## Purpose

Following [guidance from the quickstart ](https://github.com/CMSgov/macpro-quickstart-serverless/pull/556) we've bolstered the security for uploading files. 

You can test this by going to the link below. Navigate to any measure. Towards the bottom there should be an upload drop-in. Drag some files here. Try file names with invalid characters. Make sure the error message pops up. You can then check the cloudwatch logs in AWS [/aws/lambda/uploads-mdct-1842-sec-updates-avScan](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fuploads-mdct-1842-sec-updates-avScan) if you want to be extra thorough. (Need access to AWS QMR dev.)

[d1j27qj2dle7ng.cloudfront.net](d1j27qj2dle7ng.cloudfront.net)

Allowed characters: `0-9a-zA-z-_.()*`