### PR TITLE
add coreset to completed check

### DIFF
--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -239,8 +239,9 @@ const useMeasureTableDataBuilder = () => {
         }
       }
 
+      const numberOfCoreSets = 1;
       const coreSetStatus =
-        measureTableData.length === numCompleteItems
+        measureTableData.length + numberOfCoreSets === numCompleteItems
           ? CoreSetTableItem.Status.COMPLETED
           : CoreSetTableItem.Status.IN_PROGRESS;
       setCoreSetStatus(coreSetStatus);


### PR DESCRIPTION
## Purpose

Fixes an issue where people couldn't submit when they completed all measures _and_ the coreset (because then the values were unequal)

According to David all measure sets should have a coreset so this check safely works for those, as well as when someone adds measures (because # completed must match # of measures + 1)