### PR TITLE
MDCT 1914 - parse floats

### DIFF
--- a/services/ui-src/src/components/PCRRate/index.tsx
+++ b/services/ui-src/src/components/PCRRate/index.tsx
@@ -75,8 +75,8 @@ export const PCRRate = ({
   // Conditionally perform rate calculation
   const calculateRates = (prevRate: any) => {
     ndrForumlas.forEach((ndr) => {
-      const parsedNum = parseInt(prevRate[ndr.numerator]?.value);
-      const parsedDenom = parseInt(prevRate[ndr.denominator]?.value);
+      const parsedNum = parseFloat(prevRate[ndr.numerator]?.value);
+      const parsedDenom = parseFloat(prevRate[ndr.denominator]?.value);
 
       // Values empty or divide by 0
       if (


### PR DESCRIPTION
## Purpose

[MDCT-1914](https://qmacbis.atlassian.net/browse/MDCT-1914) Had an issue where a certain field that allows decimals was not calculating correctly. The reason was that we were parsing the field for integer, where the submitter is expected to provide a floating point. 

This will not impact fields that can only be integers because those do not allow you to enter a decimal.

Parsing float for both so that integer <-> float math doesn't mess with our float. Let me know if I'm wrong on that. See above point for why I'm not concerned.
