### PR TITLE
allow spaces in filename

### DIFF
--- a/services/ui-src/src/components/Upload/index.tsx
+++ b/services/ui-src/src/components/Upload/index.tsx
@@ -147,12 +147,12 @@ export const Upload = ({
   };
 
   function fileNameValidator(file: any) {
-    const fileNameRegex = new RegExp("^[0-9a-zA-z-_.()*]*$");
+    const fileNameRegex = new RegExp("^[0-9a-zA-z-_.()* ]*$");
 
     if (!fileNameRegex.test(file.name)) {
       return {
         code: "Invalid file name",
-        message: `The file name contains invalid characters. Only the following characters are allowed: A-Z, a-z, 0-9, -, _, (, ), *, and .`,
+        message: `The file name contains invalid characters. Only the following characters are allowed: A-Z, a-z, 0-9, -, _, (, ), *, ., and space`,
       };
     }
     return null;


### PR DESCRIPTION
## Description

[MDCT-2010](https://qmacbis.atlassian.net/browse/MDCT-2010) Allow spaces in upload file names.

### How to test

- Login to any state user at the [deployed url](https://d5qurnqkj3lsy.cloudfront.net/)
- Go into any measure and attempt to upload some files with different names
- It should allow spaces and the error modal should be updated to includes `space` in the acceptable character list

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
