### PR TITLE
WIP: added power to the dynamoSync function

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -75,6 +75,8 @@ layers:
 functions:
   dynamoSync:
     handler: src/dynamoSync/handler.syncDynamoToS3
+    memorySize: 4096
+    timeout: 120
     events:
       - schedule: cron(30 * * * ? *)
     environment:


### PR DESCRIPTION
## Description

The dynamoSync started failing silently on or around the 19th of December. This is the error message from Cloudfront. According to the [serverless docs](https://www.serverless.com/framework/docs/providers/aws/guide/functions/) this should buy us some runway. I think we need to evaluate a better solution for this long term. This just buys us a little more room over block leave.
`2022-12-19T06:33:36.193Z c6678057-41e8-42d6-a681-af706c80e79a Task timed out after 6.02 seconds`

I upped the memory as well as the time because we were danger close on size as well. I **think** this should work.

### Changed Dependencies

No changed dependencies, just some serverless attributes. 

## Code author checklist

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
