### PR TITLE
set formula on a new line

### DIFF
--- a/services/ui-src/src/measures/2023/AABAD/data.ts
+++ b/services/ui-src/src/measures/2023/AABAD/data.ts
@@ -5,7 +5,7 @@ export const { categories, qualifiers } = getCatQualLabels("AAB-AD");
 
 export const data: DataDrivenTypes.PerformanceMeasure = {
   customPrompt:
-    "Enter a number for the numerator and the denominator.  The measure is reported as an inverted rate. The formula for the Rate = (1 - (Numerator/Denominator)) x 100",
+    "Enter a number for the numerator and the denominator. The measure is reported as an inverted rate. <br/> The formula for the Rate = (1 - (Numerator/Denominator)) x 100",
   questionText: [
     "The percentage of episodes for beneficiaries age 18 and older with a diagnosis of acute bronchitis/bronchiolitis that did not result in an antibiotic dispensing event.",
   ],

--- a/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
+++ b/services/ui-src/src/measures/2023/shared/CommonQuestions/PerformanceMeasure/index.tsx
@@ -285,12 +285,14 @@ export const PerformanceMeasure = ({
       <CUI.Text
         fontWeight="bold"
         mt={5}
+        dangerouslySetInnerHTML={{
+          __html:
+            data.customPrompt ??
+            `Enter a number for the numerator and the denominator. Rate will
+          auto-calculate:`,
+        }}
         data-cy="Enter a number for the numerator and the denominator"
-      >
-        {data.customPrompt ??
-          `Enter a number for the numerator and the denominator. Rate will
-        auto-calculate:`}
-      </CUI.Text>
+      />
       {(dataSourceWatch?.[0] !== "AdministrativeData" ||
         dataSourceWatch?.length !== 1) && (
         <CUI.Heading pt="5" size={"sm"}>


### PR DESCRIPTION
## Description

Client requested that the formula in the text be on a new line.
The solution was to add the prop  `dangerouslySetInnerHTML` in order to add the text in a way that would allow for a line break. We don't need to worry about opening up the app to injections here because this text is pulled from a local reference (not from the db) and not user input. [Reference here](https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml)

### How to test

You should see this text in one line and breaking at the container size.

### Changed Dependencies

<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Code author checklist

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests
- [ ] I have added analytics, if necessary
- [ ] I have updated the documentation, if necessary

## Reviewer checklist (two different people)

- [ ] I have done the deep review and verified the items in the above checklist are g2g
- [ ] I have done the lgtm review
