### PR TITLE
LD flag fix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,26 @@
 ## Summary
 
 ### Description
+
 <!-- Detailed description of changes and related context -->
 
 ### Related ticket
+
 <!-- Link to related ticket or issue -->
 
 ### How to test
+
 <!-- Step-by-step instructions on how to test -->
 
 ### Important updates
+
 <!-- Any changed dependencies, .env files, local configs, etc. and
 instructions for other engineers, e.g. requires new installs in directories -->
 
 ### Author checklist
+
 <!-- Complete the following before marking ready for review -->
+
 - [ ] I have performed a self-review of my code
 - [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
 - [ ] I have updated the documentation, if necessary

--- a/services/ui-src/src/index.tsx
+++ b/services/ui-src/src/index.tsx
@@ -21,7 +21,7 @@ Amplify.configure({
 });
 
 // LaunchDarkly Configuration
-const ldClientId = process.env.REACT_APP_LD_SDK_CLIENT;
+const ldClientId = config.REACT_APP_LD_SDK_CLIENT;
 (async () => {
   const LDProvider = await asyncWithLDProvider({
     clientSideID: ldClientId!,


### PR DESCRIPTION
## Summary
Make LD flags work in deployed envs.

### Description
LD Flags were not working in the deployed envs, but were locally. They were keying off of process.env which, surprisingly, works locally, but is not available on deploy. This just swaps it over to pull from the config instead.

### Related ticket
Unblocks https://qmacbis.atlassian.net/browse/MDCT-2217

### How to test
The LD client should still configure correctly locally (check out the network tab / console logs).

### Important updates
N/A

### Author checklist
- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated the documentation, if necessary
