### PR TITLE
Rename existing WAF to fix existing environment build failure

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -36,7 +36,7 @@ custom:
   wafExcludeRules:
     wafScope: CLOUDFRONT
   wafPlugin:
-    name: ${self:service}-${self:custom.stage}-webacl
+    name: ${self:service}-${self:custom.stage}-webacl-waf
     rules:
       - enable: ${param:restrictToVpn}
         rule:


### PR DESCRIPTION
### Description
upon merging to the main integration branch (in QMR's case master) the deploy failed updating the WAF with the following error. 

`Error:
CREATE_FAILED: WafPluginAcl (AWS::WAFv2::WebACL)
Resource handler returned message: "AWS WAF couldn?t perform the operation because some resource in your request is a duplicate of an existing one. (Service: Wafv2, Status Code: 400, Request ID: 24371deb-7bc0-42ba-a855-12bec4e67b5b)" (RequestToken: 30c004da-370d-38d2-3561-be2fc9a79ea4, HandlerErrorCode: AlreadyExists)`

This PR is to rename the waf to a unique name to allow the deploy to run through successfully. 

### Related ticket(s)
https://jiraent.cms.gov/browse/CMDCT-2942

---
### How to test
Merge and verify deploy runs through cleanly in the master branch as well as go to aws console and verify the rename


### Important updates
upon success copy this PR over to the exiting PR so it is not lost for updating other products.
https://github.com/Enterprise-CMCS/macpro-mdct-qmr/pull/2036


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
