### PR TITLE
[Fix] Parser to be Recursive

### DIFF
--- a/services/ui-src/src/utils/parser.test.ts
+++ b/services/ui-src/src/utils/parser.test.ts
@@ -26,4 +26,12 @@ describe("Test parseLabelToHTML", () => {
       "Unrecognized node type in label:\n" + label
     );
   });
+
+  it("Test that attributes are copied", () => {
+    const label = `<a href="https://example.com/">test</a>`;
+    const parsedLabel = parseLabelToHTML(label);
+    const { container } = render(parsedLabel);
+    const link = container.querySelector("a")!;
+    expect(link.href).toBe("https://example.com/");
+  });
 });

--- a/services/ui-src/src/utils/parser.tsx
+++ b/services/ui-src/src/utils/parser.tsx
@@ -1,53 +1,41 @@
-import React from "react";
+import React, { JSXElementConstructor, ReactElement } from "react";
 import { v4 as uuidv4 } from "uuid";
 
-//creating a react element from html elements
-const reactElement = (element: Element, reactElements?: any) => {
-  //create a react element with a random key to prevent browser warning
-  return React.createElement(
-    element.tagName.toLowerCase(),
-    { key: uuidv4() },
-    reactElements ?? element.innerHTML
-  );
-};
-
-//recusively look through html elements and convert any tags to react elements
-const convertToReactElement = (element: Element) => {
-  if (
-    element.childNodes.length === 1 &&
-    element.childNodes[0] instanceof Text
-  ) {
-    return reactElement(element);
-  } else {
-    let reactElements: React.DOMElement<
-      React.DOMAttributes<Element>,
-      Element
-    >[] = [];
-    element.childNodes.forEach((node: ChildNode) => {
-      reactElements.push(convertToReactElement(node as Element));
-    });
-    return reactElement(element, reactElements);
-  }
-};
-
-//convert labels with html tags to JSX elements to be rendered, doesn't work with <br> tags
+/**
+ * Convert labels with HTML tags to JSX elements to be rendered.
+ *
+ * Doesn't work with `<br>` tags.
+ */
 export const parseLabelToHTML = (label: string) => {
-  const parseLabel = new DOMParser().parseFromString(label, "text/html").body;
-  let renderArr: (
-    | string
-    | React.DOMElement<React.DOMAttributes<Element>, Element>
-    | null
-  )[] = [];
-  parseLabel.childNodes.forEach((node: ChildNode) => {
+  const attributesOf = (element: Element) => {
+    return Object.fromEntries(
+      [...element.attributes].map((attr) => [attr.name, attr.value])
+    );
+  };
+
+  const convertNodetoReactElement = (node: Node): StringOrElement => {
     if (node instanceof Text) {
-      renderArr.push(node.textContent);
+      // Text nodes always have textContent.
+      return node.textContent!;
     } else if (node instanceof Element) {
-      //convert any tags and inner tags into react elements
-      renderArr.push(convertToReactElement(node));
+      const tagName = node.tagName.toLowerCase();
+      const props = {
+        // The random key prevents browser warnings.
+        key: uuidv4(),
+        ...attributesOf(node),
+      };
+      const children = [...node.childNodes].map(convertNodetoReactElement);
+      return React.createElement(tagName, props, children);
     } else {
-      // throw new Error("Unrecognized node type in label:\n" + label);
-      throw new Error("Unrecognized node type in label:\n" + label);
+      throw new Error(`Unrecognized node type in label:\n${label}`);
     }
-  });
-  return <>{renderArr}</>;
+  };
+
+  const body = new DOMParser().parseFromString(label, "text/html").body;
+  const elements = [...body.childNodes].map(convertNodetoReactElement);
+  return <>{elements}</>;
 };
+
+type StringOrElement =
+  | string
+  | ReactElement<Record<string, any>, string | JSXElementConstructor<any>>;

--- a/services/ui-src/tsconfig.json
+++ b/services/ui-src/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "incremental": true,
     "target": "ES2020",
-    "lib": ["es6", "dom", "ES2021"],
+    "lib": ["es6", "dom", "ES2021", "dom.iterable"],
     "jsx": "react-jsx",
     "sourceMap": true,
     "module": "esnext",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Upgrading the html parser based on @benmartin-coforma feedback.
1) Change conditionals to check type of node instead of truthiness and added the error recommended.
2) Parser now recurse through the string for any inner tags. Nested tags should not be a problem anymore.
3) Added the recursive test that Ben provided into the unit test and also added a new one to test the error message.

Note: I choose to stay with the forEach loop instead of converting it to an array to be able to use map.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3338

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR
2) Stay in reporting year 2024
3) Go to any adult measures
4) Addtional Note should render like this:

> Please add any additional notes or comments on the measure not otherwise captured above (_text in this field is included in publicly-reported state-specific comments_):

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
