### PR TITLE
QMR VPN Deploy Workflow refactor for consistency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
         id: get-gha-cidrs
         shell: bash
         run: |
-          #! /bin/bash
+          #!/bin/bash
           GHA_RESP=$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/meta)
           echo "Response for GHA runner CIDR blocks:  $GHA_RESP"
           IPV4_CIDR_ARR=($(echo $GHA_RESP | jq -r '.actions | .[]' | grep -v ':'))


### PR DESCRIPTION
### Description
As we rolled out the vpn restriction to other products we learned more and refined the process. This PR is to bring back those changes to have more consistency across our products. 

What this adds:
1) it breaks out the register GitHub runner to its own unique step enabling us to skip this step and in turn skip the delist step in environments where we don't run tests.  See the following actions run for an example where I added the vpn-refactor branch into the deploy workflow where it was treated as an integration branch. We got the results we would expect where it does the deploy and that's it. 
https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/runs/8366009772

2) Removes some unneeded code 

See below actions run for example of what we would expect in ephemeral branches where all tests are run and register and delist steps are executed
https://github.com/Enterprise-CMCS/macpro-mdct-qmr/actions/runs/8375724598



note: this does not change the behavior of VPN at all merely just some GitHub workflow changes. 

### Related ticket(s)
n/a

---
### How to test
see above for explication of test cases performed 


### Important updates
this will now skip the register runner and delist steps in integration environments where we do not have the vpn restriction.


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
