### PR TITLE
Run a11y tests in parallel to speed up pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -314,7 +314,6 @@ jobs:
     name: Accessibility Tests
     needs:
       - e2e-tests-init
-      # - setup-tests
     uses: ./.github/workflows/cypress-workflow.yml
     with:
       test-path: "a11y"


### PR DESCRIPTION
### Description
This PR is to run the a11y accessibility tests in parallel to the e2e tests in an effort to cut down the deploy time of QMR. 

Experimenting it looks like a previous run where the a11y tests run after the e2e tests on a second run (not initial deploy) takes about 19.5 mins 
![Screenshot 2024-03-21 at 8 22 19 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/52459927/a5fcd519-d8f1-4f63-a9d9-e2276afca2b2)

Moving the a11y tests to run in parallel and not after e2e is ~3.5 mins shorter and runs through without issue.
![Screenshot 2024-03-21 at 8 17 30 PM](https://github.com/Enterprise-CMCS/macpro-mdct-qmr/assets/52459927/03044c0f-b457-4882-bf1f-7bc4151ec275)


### Related ticket(s)
https://jiraent.cms.gov/browse/CMDCT-3438
---
### How to test
keep an eye on the pipeline an ensure we don't see adverse effects of running this in parallel but initial testing looks good. 


### Important updates
na/


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
