### PR TITLE
Allowing other territories into QMR via latest WAF plugin release

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@stratiformdigital/serverless-stage-destroyer": "^2.0.0"
   },
   "dependencies": {
-    "@enterprise-cmcs/serverless-waf-plugin": "^1.3.2",
+    "@enterprise-cmcs/serverless-waf-plugin": "^1.4.0",
     "xml2js": "0.6.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2516,10 +2516,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@enterprise-cmcs/serverless-waf-plugin@^1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@enterprise-cmcs/serverless-waf-plugin/-/serverless-waf-plugin-1.3.2.tgz#66efd0b91326b7d1b045ab7ea7ba5826ed2e635d"
-  integrity sha512-577MWRddWK2uPEaeUMorOFQq6rhUhGwbdmz+tuKaU9+v77/bDQPqoc6cmhF2oYMswqpxvMgW0P07HAAcmKtquw==
+"@enterprise-cmcs/serverless-waf-plugin@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@enterprise-cmcs/serverless-waf-plugin/-/serverless-waf-plugin-1.4.0.tgz#f1af6d64726c067bc8eaece714b15e73dccf5a6d"
+  integrity sha512-hKmIa4b11iMfcHnhgoxS12z51rGSJZG2/L4AuM2s+vC1a1+7rvN7JyaiWFgppoInr510aGAfrm1BGCV1VU1eTw==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
### Description
MDCT had an issue with users from American Samoa trying to access MFP and were unable to access due to current WAF rules inherited from the serverless-waf-plugin. A pull request was created https://github.com/Enterprise-CMCS/serverless-waf-plugin/pull/10 to allow appropriate US territories into the applications. This PR simply pulls in the latest plugin release to resolve the issue.


### Related ticket(s)


---
### How to test



### Notes



---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
