### PR TITLE
adding waf for cognito

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -29,11 +29,17 @@ plugins:
   - serverless-bundle
   - serverless-iam-helper
   - serverless-s3-bucket-helper
+  - "@enterprise-cmcs/serverless-waf-plugin"
 
 custom:
   project: "qmr"
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
+  wafPlugin:
+    name: ${self:service}-${self:custom.stage}-webacl-waf
+  wafExcludeRules:
+    awsCommon:
+      - "SizeRestrictions_BODY"
   serverlessTerminationProtection:
     stages:
       - master
@@ -99,6 +105,18 @@ resources:
               MaxLength: 256
         AdminCreateUserConfig:
           AllowAdminCreateUserOnly: True # This setting disables self sign-up for users
+        UserPoolAddOns:
+          AdvancedSecurityMode: ENFORCED
+        UserPoolTags:
+          Name: ${self:custom.stage}-user-pool
+
+    # Associate the WAF Web ACL with the Cognito User Pool
+    CognitoUserPoolWAFAssociation:
+      Type: 'AWS::WAFv2::WebACLAssociation'
+      Properties:
+        ResourceArn: !GetAtt CognitoUserPool.Arn
+        WebACLArn: !GetAtt WafPluginAcl.Arn
+
     CognitoUserPoolClient:
       Type: AWS::Cognito::UserPoolClient
       Properties:


### PR DESCRIPTION
### Description
AWS Cognito has API endpoints that are public similar to api gateway or cloudfront it is a good practice to protect this resource with a web application firewall (WAF) to restrict traffic and provide additional security measures from the firewall. This PR adds a WAF to cognito following the pattern of the other MDCT apps.

https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-waf.html


### Related ticket(s)
https://jiraent.cms.gov/browse/CMDCT-3665

---
### How to test
after merge to main log into main env with idm user to verify no issues are seen.


### Notes
I'm not crazy about adding more severless changes as we're attempting to migrate to the cdk but its a fairly straight approach from our other services so when we do waf changes in any other service for cdk that will just carry over to here.


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
