### PR TITLE
CMDCT-4865 - update validation function

### DIFF
--- a/services/ui-src/src/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/shared/globalValidations/omsValidator/index.ts
@@ -264,15 +264,25 @@ const validateNDR = (
     const midKey = rates[topKey];
     errors.push(
       Object.keys(midKey)
-        .filter(
-          (qualId) =>
-            !midKey[qualId].every(
-              (ndr) => ndr.numerator && ndr.denominator && ndr.rate
-            )
-        )
-        .map((qualId) =>
-          errorToFillNDR(`${labels} - ${locationDictionary([topKey, qualId])}`)
-        )
+        .filter((qualId) => {
+          // Only consider NDRs that are not all empty strings
+          const relevantNDRs = midKey[qualId].filter(
+            (ndr) =>
+              !(
+                ndr.numerator === "" &&
+                ndr.denominator === "" &&
+                ndr.rate === ""
+              )
+          );
+          return !relevantNDRs.every(
+            (ndr) => ndr.numerator && ndr.denominator && ndr.rate
+          );
+        })
+        .map((qualId) => {
+          return errorToFillNDR(
+            `${labels} - ${locationDictionary([topKey, qualId])}`
+          );
+        })
     );
   }
   return errors.flat();


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Typing anything into the optional NDR fields and then clearing would still send the empty rates data to `validateNDR()`. This PR changes it to first filter any rates that are completely empty


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4865

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Login: https://dc9eoumm4iklx.cloudfront.net/
- Sign into QMR, any state user (i.e. [stateuser1@test.com](mailto:stateuser1@test.com))
- In reporting year 2025, select any measure that has a Measure Stratification section (i.e. AAB-CH)
- In the Measure Specification section, select the first radio button, this will enable the Performance Measure section
- Scroll down to the Performance Measure section and fill out the N/D/R sets. This will enable the Measure Stratification section
- Go to the Measure Stratification section and in the radio button section select either 1997 or 2024
- Fill out one of the optional num/denom under race/Amarican/Alaska
- Click validate to make sure its not erroring (makes it easier to test if you fill out the rest of the survey)
- Clear the optional num/denom, and validate again to make sure its still not erroring


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
