### PR TITLE
Remove duplicative alt text; the button text suffices

### DIFF
--- a/services/ui-src/src/components/Header/index.tsx
+++ b/services/ui-src/src/components/Header/index.tsx
@@ -22,7 +22,7 @@ export function Header({ handleLogout }: Props) {
             <CUI.Button onClick={handleLogout} variant="link-white">
               <CUI.Image
                 src="/header/logout.svg"
-                alt="logout"
+                alt=""
                 sx={{ maxWidth: "24px", marginRight: "0.25rem" }}
               />
               <CUI.Hide below="md">Logout</CUI.Hide>


### PR DESCRIPTION
### Description
This is a small quality-of-life improvement for screen readers. They would read the alt text on the image and also the text on the button; when the image is just an icon with the same meaning as the text, this can be redundant. In this case, the logout button would be announced as "logout logout".

The fix is straightforward: In order to tell screen readers to ignore the image and announce only the text, we need to mark that image as presentational. Giving it `alt=""` does exactly that.

Note that this behaves differently from removing the `alt` attribute altogether. If there is no alt at all, some screen readers will assume it was neglected, and announce the image's file name instead as a best effort to inform their users of what the screen contains. See also: https://www.w3.org/WAI/tutorials/images/decorative/

### Related ticket(s)
CMDCT-4776

---
### How to test
https://d2wb7ohzls4k6w.cloudfront.net/

1. On the home page, turn on your screen reader, and give focus to the logout button.
2. Confirm that the reader announces "logout: button" (or similar) and not "logout logout: button"


### Notes
n/a

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- ~[ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- ~[ ] Product: This work has been reviewed and approved by product owner, if necessary~

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
