### PR TITLE
[CMDCT-4826] Table links don't show focus in Chrome & Safari

### DIFF
--- a/services/ui-src/src/components/Table/columns/coreSets.tsx
+++ b/services/ui-src/src/components/Table/columns/coreSets.tsx
@@ -46,8 +46,7 @@ export const coreSetColumns: TableColumn<CoreSetTableItem.Data>[] = [
         <CUI.Link
           as={Link}
           to={data.coreSet}
-          color="blue.600"
-          fontWeight="bold"
+          variant="unlined"
           data-cy={data.coreSet}
         >
           {data.title}

--- a/services/ui-src/src/components/Table/columns/measures.tsx
+++ b/services/ui-src/src/components/Table/columns/measures.tsx
@@ -66,8 +66,7 @@ export const measuresColumns = (
           <CUI.Link
             as={Link}
             to={data.path}
-            fontWeight="bold"
-            color="blue.600"
+            variant="unlined"
             data-cy={data.abbr}
           >
             {data.abbr}
@@ -83,8 +82,7 @@ export const measuresColumns = (
           <CUI.Link
             as={Link}
             to={data.path}
-            fontWeight="bold"
-            color="blue.600"
+            variant="unlined"
             data-cy={data.path}
           >
             {data.title}

--- a/services/ui-src/src/styles/components/link.ts
+++ b/services/ui-src/src/styles/components/link.ts
@@ -5,8 +5,18 @@ const baseStyles = {
   color: "blue.600",
 };
 
+const unlinedVariant = {
+  textDecoration: "none",
+  fontWeight: "bold",
+};
+
+const variants = {
+  unlined: unlinedVariant,
+};
+
 const linkTheme: ComponentStyleConfig = {
   baseStyle: baseStyles,
+  variants: variants,
 };
 
 export default linkTheme;

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -42,8 +42,7 @@ const GetColumns = () => {
             as={Link}
             to={data.path}
             aria-label={data.title}
-            fontWeight="bold"
-            color="blue.600"
+            variant="unlined"
             data-cy={data.path}
           >
             {data.title}

--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -94,7 +94,7 @@ const QualifiersStatusAndLink = ({ coreSetId }: { coreSetId: CoreSetAbbr }) => {
       <CUI.Link
         as={Link}
         to={"CSQ"}
-        color="blue"
+        variant="unlined"
         data-cy="core-set-qualifiers-link"
       >
         {coreSetTitles(coreSetInfo[0], "Questions") + spaName}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The table links aren't showing a focus indicator. This is caused by the fact that QMR has a Text renderer inside all the Link renderer for some reason? I moved those all to chakra links, removed the text renders and added a variant to style the link.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4826

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into QMR, any state user
2) Tab around until you see the focus indicators on the table.

<img width="795" height="452" alt="Screenshot 2025-08-27 at 10 29 42 AM" src="https://github.com/user-attachments/assets/2d79d58f-286b-4f5a-9027-05ea1f59492b" />

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
