### PR TITLE
[QMR] pageView firing twice fix

### DIFF
--- a/services/ui-src/src/App.tsx
+++ b/services/ui-src/src/App.tsx
@@ -16,7 +16,7 @@ const App = () => {
   // fire tealium page view on route change
   useEffect(() => {
     fireTealiumPageView(user, window.location.href, pathname);
-  }, [key, pathname, user]);
+  }, [key]);
 
   const authenticatedRoutes = (
     <>


### PR DESCRIPTION
### Description
During a validation call with BlastX Consulting, it was found that "pageView" was being fired twice. For some reason, it was firing at login before being authenticated and once again upon logging in.

### Related ticket(s)
CMDCT-5066

---

### How to test

1. Checkout branch locally: **qmr-teakey**
2. Login to QMR
3. Check Network Tab
4. Copy and paste into the filter to view utag specific network activity: `/utag|digitalgov|interact/`
5. And confirm that interact... only fires once (PageView)

      <img width="450" height="450" alt="Website's Network Activity showing Tealium calls with interact firing only once" src="https://github.com/user-attachments/assets/eb7736bc-2573-4948-8eeb-c3f284e15a01" />
