### PR TITLE
CMDCT-5098 - added tests for Stratification component

### DIFF
--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/Stratification/index.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/Stratification/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { Stratification } from ".";
 import { toHaveNoViolations } from "jest-axe";
 import axe from "@ui-src/axe-helper";
@@ -64,11 +64,24 @@ const TestComponent = () => {
 };
 
 describe("Test Stratification Component", () => {
-  test("Renders withouth issue", () => {
+  test("Renders without issue", () => {
     render(<TestComponent />);
     expect(
       screen.getByText("Enter Measure Stratification")
     ).toBeInTheDocument();
+  });
+
+  test("Oms checkbox functionality", () => {
+    render(<TestComponent />);
+    expect(screen.queryByText("Korean")).not.toBeInTheDocument();
+    fireEvent.click(
+      screen.getByText(
+        "No, we are reporting disaggregated data for Asian subcategories."
+      )
+    );
+    expect(screen.queryByText("Korean")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Clear"));
+    expect(screen.queryByText("Korean")).not.toBeInTheDocument();
   });
 
   test("Should not have basic accessibility issues", async () => {


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description

<!-- Detailed description of changes and related context -->
- Added a couple of simple tests to cover *most* of the file

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5098

---

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->
- Run this locally `yarn test Stratification/index.test.tsx --no-cache  --coverage --collectCoverageFrom=src/shared/commonQuestions/MeasureStratification/Stratification/index.tsx` or check the QLTY report.

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
