### PR TITLE
[QMR] - Tab Title Updates to Match HCBS for Consistency

### DIFF
--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -422,7 +422,7 @@ export const MeasureWrapper = ({
     `- ${formatTitle(apiData?.Item?.description)}`;
 
   // Individual Measures -> "AAB-CH - Medicaid: Child Core Set Measures - 2025 QMR"
-  const pageTitle = (() => {
+  const tabTitle = (() => {
     const coreSetTitle = coreSetTitles(coreSet);
 
     // Qualifiers -> "Qualifiers - Child Core Set Measures: Medicaid - 2025 QMR"
@@ -461,7 +461,7 @@ export const MeasureWrapper = ({
 
   return (
     <FormProvider {...methods}>
-      <QMR.Title pageTitle={pageTitle} />
+      <QMR.Title tabTitle={tabTitle} />
       <QMR.YesNoModalDialog
         isOpen={showModal}
         headerText="Validation Error"

--- a/services/ui-src/src/components/Title/index.tsx
+++ b/services/ui-src/src/components/Title/index.tsx
@@ -5,11 +5,9 @@ interface TitleProps {
 }
 
 export const Title = ({ pageTitle }: TitleProps) => {
-  const fullTitle = `${pageTitle}`;
-
   return (
     <Helmet>
-      <title>{fullTitle}</title>
+      <title>{pageTitle}</title>
     </Helmet>
   );
 };

--- a/services/ui-src/src/components/Title/index.tsx
+++ b/services/ui-src/src/components/Title/index.tsx
@@ -1,13 +1,13 @@
 import { Helmet } from "react-helmet-async";
 
 interface TitleProps {
-  pageTitle: string;
+  tabTitle: string;
 }
 
-export const Title = ({ pageTitle }: TitleProps) => {
+export const Title = ({ tabTitle }: TitleProps) => {
   return (
     <Helmet>
-      <title>{pageTitle}</title>
+      <title>{tabTitle}</title>
     </Helmet>
   );
 };

--- a/services/ui-src/src/views/AddAdultCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddAdultCoreSet/index.tsx
@@ -70,7 +70,7 @@ export const AddAdultCoreSet = () => {
 
   return (
     <>
-      <QMR.Title pageTitle={`Add Adult Core Set - ${year} QMR`} />
+      <QMR.Title tabTitle={`Add Adult Core Set - ${year} QMR`} />
       <QMR.StateLayout
         breadcrumbItems={[
           {

--- a/services/ui-src/src/views/AddChildCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddChildCoreSet/index.tsx
@@ -70,7 +70,7 @@ export const AddChildCoreSet = () => {
 
   return (
     <>
-      <QMR.Title pageTitle={`Add Child Core Set - ${year} QMR`} />
+      <QMR.Title tabTitle={`Add Child Core Set - ${year} QMR`} />
       <QMR.StateLayout
         breadcrumbItems={[
           {

--- a/services/ui-src/src/views/AddHHCoreSet/index.tsx
+++ b/services/ui-src/src/views/AddHHCoreSet/index.tsx
@@ -84,7 +84,7 @@ export const AddHHCoreSet = () => {
 
   return (
     <>
-      <QMR.Title pageTitle={`Add Health Home Core Set - ${year} QMR`} />
+      <QMR.Title tabTitle={`Add Health Home Core Set - ${year} QMR`} />
       <QMR.StateLayout
         breadcrumbItems={[
           {

--- a/services/ui-src/src/views/AdminHome/index.tsx
+++ b/services/ui-src/src/views/AdminHome/index.tsx
@@ -19,7 +19,7 @@ export const AdminHome = () => {
 
   return (
     <>
-      <QMR.Title pageTitle={`Admin Home - ${releaseYearByFlag} QMR`} />
+      <QMR.Title tabTitle={`Admin Home - ${releaseYearByFlag} QMR`} />
       <CUI.Container maxW="7xl" py="4">
         <CUI.Box py="4">
           <BannerCard />

--- a/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/CombinedRatesMeasure.tsx
@@ -58,7 +58,7 @@ export const CombinedRatesMeasure = ({
 
   return (
     <>
-      <QMR.Title pageTitle={`${measure} - Combined Rates - ${year} QMR`} />
+      <QMR.Title tabTitle={`${measure} - Combined Rates - ${year} QMR`} />
       <QMR.StateLayout
         breadcrumbItems={[
           {

--- a/services/ui-src/src/views/CombinedRatesPage/index.tsx
+++ b/services/ui-src/src/views/CombinedRatesPage/index.tsx
@@ -135,7 +135,7 @@ export const CombinedRatesPage = () => {
   return (
     <>
       <QMR.Title
-        pageTitle={`Combined Rates - Core Set Measures - ${year} QMR`}
+        tabTitle={`Combined Rates - Core Set Measures - ${year} QMR`}
       />
       <QMR.StateLayout
         breadcrumbItems={[

--- a/services/ui-src/src/views/CoreSet/index.tsx
+++ b/services/ui-src/src/views/CoreSet/index.tsx
@@ -443,11 +443,11 @@ export const CoreSet = () => {
     formattedSpaName = `: ${tempSpa.state} ${tempSpa.id}`;
   }
 
-  const pageTitle = `${simplifiedTitle}${formattedSpaName} - Core Set Measures - ${year} QMR`;
+  const tabTitle = `${simplifiedTitle}${formattedSpaName} - Core Set Measures - ${year} QMR`;
 
   return (
     <>
-      <QMR.Title pageTitle={pageTitle} />
+      <QMR.Title tabTitle={tabTitle} />
       <QMR.StateLayout
         breadcrumbItems={[
           {

--- a/services/ui-src/src/views/StateHome/index.tsx
+++ b/services/ui-src/src/views/StateHome/index.tsx
@@ -296,7 +296,7 @@ const StateHome = () => {
 
   return (
     <>
-      <QMR.Title pageTitle={`Core Set Measures - ${year} QMR`} />
+      <QMR.Title tabTitle={`Core Set Measures - ${year} QMR`} />
       <QMR.StateLayout
         breadcrumbItems={[
           { path: `/${state}/${year}`, name: "Core Set Measures" },


### PR DESCRIPTION
### Description
- fullTitle not needed, it may have had more text at one point but it doesn't anymore
- string interpolation also not needed anymore
- update `pageTitle` to `tabTitle` to match HCBS naming and provide consistency across apps

### Related ticket(s)
Quick fix inspired by updates to HCBS in this ticket: [CMDCT-5732: [HCBS] Critical Incidents - Page Titles](https://jiraent.cms.gov/browse/CMDCT-5732)

### How to test

**Deploy Link:** https://d3hue6tnpsq45d.cloudfront.net/

- No functionality updates.
- Table titles should be unchanged and show up as expected.

---
### Pre-review checklist
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment