### PR TITLE
QMR [2026] Adult Core Set Updates

### DIFF
--- a/services/ui-src/src/measures/2026/AISAD/data.ts
+++ b/services/ui-src/src/measures/2026/AISAD/data.ts
@@ -10,7 +10,7 @@ export const data: MeasureTemplateData = {
   hybridMeasure: true,
   performanceMeasure: {
     questionText: [
-      "The percentage of beneficiaries age 19 and older who are up to date on recommended routine vaccines for influenza, tetanus and diphtheria (Td) or tetanus, diphtheria and acellular pertussis (Tdap), zoster and pneumococcal.",
+      "The percentage of beneficiaries age 19 and older who are up to date on recommended routine vaccines for influenza, tetanus and diphtheria (Td) or tetanus, diphtheria and acellular pertussis (Tdap), zoster,  pneumococcal, and hepatitis B.",
     ],
     questionListItems: [],
     categories,

--- a/services/ui-src/src/measures/2026/BCSAD/data.ts
+++ b/services/ui-src/src/measures/2026/BCSAD/data.ts
@@ -9,7 +9,7 @@ export const data: MeasureTemplateData = {
   coreset: "adult",
   performanceMeasure: {
     questionText: [
-      "Percentage of beneficiaries ages 50 to 74 who were recommended for routine breast cancer screening and had a mammogram to screen for breast cancer.",
+      "The percentage of beneficiaries ages 40 to 74 who were recommended for routine breast cancer screening and had a mammogram to screen for breast cancer. This measure applies to beneficiaries ages 42 to 74 to account for the 2-year, 3-month look-back period.",
     ],
     questionListItems: [],
     categories,

--- a/services/ui-src/src/measures/2026/CCSAD/data.ts
+++ b/services/ui-src/src/measures/2026/CCSAD/data.ts
@@ -24,34 +24,6 @@ export const data: MeasureTemplateData = {
     optionsLabel:
       "If reporting entities (e.g., health plans) used different data collection methods, please select all that are applicable below. If your state followed the 2026 Core Set technical specifications and used administrative data only, select ECDS > Administrative.",
     options: [
-      {
-        value: DC.ADMINISTRATIVE_DATA,
-        subOptions: [
-          {
-            label: "What is the Administrative Data Source?",
-            options: [
-              { value: DC.MEDICAID_MANAGEMENT_INFO_SYSTEM },
-              { value: DC.ADMINISTRATIVE_DATA_OTHER, description: true },
-            ],
-          },
-        ],
-      },
-      {
-        value: DC.HYBRID_DATA,
-        subOptions: [
-          {
-            label: "What is the Administrative Data Source?",
-            options: [
-              { value: DC.MEDICAID_MANAGEMENT_INFO_SYSTEM },
-              { value: DC.ADMINISTRATIVE_DATA_OTHER, description: true },
-            ],
-          },
-          {
-            label: "What is the Medical Records Data Source?",
-            options: [{ value: DC.EHR_DATA }, { value: DC.PAPER }],
-          },
-        ],
-      },
       { value: DC.ELECTRONIC_HEALTH_RECORDS, description: true },
       {
         value: DC.ELECTRONIC_CLINIC_DATA_SYSTEMS,

--- a/services/ui-src/src/measures/2026/CHLAD/data.ts
+++ b/services/ui-src/src/measures/2026/CHLAD/data.ts
@@ -9,7 +9,7 @@ export const data: MeasureTemplateData = {
   coreset: "adult",
   performanceMeasure: {
     questionText: [
-      "Percentage of women ages 21 to 24 who were identified as sexually active and who had at least one test for chlamydia during the measurement year.",
+      "Percentage of beneficiaries ages 21 to 24 who were recommended for routine chlamydia screening, were identified as sexually active, and had at least one test for chlamydia during the measurement year.",
     ],
     questionListItems: [],
     categories,

--- a/services/ui-src/src/measures/2026/COBAD/data.ts
+++ b/services/ui-src/src/measures/2026/COBAD/data.ts
@@ -8,7 +8,7 @@ export const data: MeasureTemplateData = {
   coreset: "adult",
   performanceMeasure: {
     questionText: [
-      "Percentage of beneficiaries age 18 and older with concurrent use of prescription opioids and benzodiazepines. Beneficiaries with a cancer diagnosis, sickle cell disease diagnosis, or in hospice or palliative care are excluded.",
+      "Percentage of beneficiaries age 18 and older with concurrent use of prescription opioids and benzodiazepines. Beneficiaries with a cancer diagnosis, receiving treatment for cancer-related pain, sickle cell disease diagnosis, or in hospice or palliative care are excluded.",
     ],
     questionListItems: [],
     categories,

--- a/services/ui-src/src/measures/2026/FUHAD/data.ts
+++ b/services/ui-src/src/measures/2026/FUHAD/data.ts
@@ -8,11 +8,11 @@ export const data: MeasureTemplateData = {
   coreset: "adult",
   performanceMeasure: {
     questionText: [
-      "The percentage of discharges for beneficiaries age 18 and older who were hospitalized for treatment of selected mental illness or intentional self-harm diagnoses and who had a follow-up visit with a mental health provider. Two rates are reported:",
+      "Percentage of discharges for beneficiaries age 18 and older who were hospitalized for a principal diagnosis of mental illness, or any diagnosis of intentional self-harm, and had a mental health follow-up service . Two rates are reported:",
     ],
     questionListItems: [
-      "Percentage of discharges for which the beneficiary received follow-up within 30 days after discharge",
-      "Percentage of discharges for which the beneficiary received follow-up within 7 days after discharge",
+      "Percentage of discharges for which the enrollee received follow-up within 30 days after discharge",
+      "Percentage of discharges for which the enrollee received follow-up within 7 days after discharge",
     ],
     categories,
     qualifiers,

--- a/services/ui-src/src/measures/2026/FUMAD/data.ts
+++ b/services/ui-src/src/measures/2026/FUMAD/data.ts
@@ -8,7 +8,7 @@ export const data: MeasureTemplateData = {
   coreset: "adult",
   performanceMeasure: {
     questionText: [
-      "Percentage of emergency department (ED) visits for beneficiaries age 18 and Older with a principal diagnosis of mental illness or intentional self-harm and who had a follow-up visit for mental illness. Two rates are reported:",
+      "Percentage of emergency department (ED) visits for beneficiaries age 18 and older with a principal diagnosis of mental illness, or any diagnosis of intentional self-harm and had a mental health follow-up service. Two rates are reported:",
     ],
     questionListItems: [
       "Percentage of ED visits for which the beneficiary received follow-up within 30 days of the ED visit (31 total days)",

--- a/services/ui-src/src/measures/2026/OEVPAD/data.ts
+++ b/services/ui-src/src/measures/2026/OEVPAD/data.ts
@@ -8,7 +8,7 @@ export const data: MeasureTemplateData = {
   coreset: "adult",
   performanceMeasure: {
     questionText: [
-      "Percentage of enrolled persons ages 21 to 44 with live-birth deliveries in the measurement year who received a comprehensive or periodic oral evaluation during pregnancy.",
+      "The percentage of enrolled persons ages 21 through 44 with live-birth deliveries in the measurement year who received a comprehensive or periodic oral evaluation during pregnancy.",
     ],
     categories,
     qualifiers,

--- a/services/ui-src/src/measures/2026/PDSAD/data.ts
+++ b/services/ui-src/src/measures/2026/PDSAD/data.ts
@@ -5,7 +5,7 @@ import * as DC from "dataConstants";
 export const { categories, qualifiers } = getCatQualLabels("PDS-AD");
 
 export const data: MeasureTemplateData = {
-  type: "HEDIS",
+  type: "NCQA/HEDIS",
   coreset: "adult",
   performanceMeasure: {
     questionText: [

--- a/services/ui-src/src/measures/2026/PDSAD/data.ts
+++ b/services/ui-src/src/measures/2026/PDSAD/data.ts
@@ -9,7 +9,7 @@ export const data: MeasureTemplateData = {
   coreset: "adult",
   performanceMeasure: {
     questionText: [
-      "The percentage of deliveries in which beneficiaries were screened for clinical depression during the postpartum period, and if screened positive, received follow-up care.",
+      "The percentage of deliveries in which beneficiaries age 21 and older were screened for clinical depression during the postpartum period, and if screened positive, received follow-up care.",
     ],
     questionListTitles: [
       "Depression Screening. ",

--- a/services/ui-src/src/measures/2026/PDSAD/data.ts
+++ b/services/ui-src/src/measures/2026/PDSAD/data.ts
@@ -5,7 +5,7 @@ import * as DC from "dataConstants";
 export const { categories, qualifiers } = getCatQualLabels("PDS-AD");
 
 export const data: MeasureTemplateData = {
-  type: "NCQA/HEDIS",
+  type: "HEDIS",
   coreset: "adult",
   performanceMeasure: {
     questionText: [

--- a/services/ui-src/src/measures/2026/PNDAD/data.ts
+++ b/services/ui-src/src/measures/2026/PNDAD/data.ts
@@ -9,7 +9,7 @@ export const data: MeasureTemplateData = {
   coreset: "adult",
   performanceMeasure: {
     questionText: [
-      "The percentage of deliveries in which beneficiaries age 21 and older were screened for clinical depression while pregnant, and if screened positive, received follow-up care.",
+      "The percentage of deliveries in which beneficiaries age 21 and older were screened for clinical depression while pregnant and, if screened positive, received follow-up care.",
     ],
     questionListTitles: [
       "Depression Screening. ",

--- a/services/ui-src/src/measures/2026/PPC2AD/data.ts
+++ b/services/ui-src/src/measures/2026/PPC2AD/data.ts
@@ -10,7 +10,7 @@ export const data: MeasureTemplateData = {
   hybridMeasure: true,
   performanceMeasure: {
     questionText: [
-      "Percentage of deliveries of live births on or between October 8 of the year prior to the measurement year and October 7 of the measurement year. For these beneficiaries, the measure assesses the following facets of prenatal and postpartum care:",
+      "Percentage of deliveries of live births on or between October 8 of the year prior to the measurement year and October 7 of the measurement year for beneficiaries age 21 and older. For these beneficiaries, the measure assesses the following facets of prenatal and postpartum care.",
     ],
     questionListItems: [
       "Timeliness of Prenatal Care: Percentage of deliveries that received a prenatal care visit in the first trimester, on or before the enrollment start date or within 42 days of enrollment in Medicaid/CHIP.",

--- a/services/ui-src/src/measures/2026/PRSAD/data.ts
+++ b/services/ui-src/src/measures/2026/PRSAD/data.ts
@@ -9,7 +9,7 @@ export const data: MeasureTemplateData = {
   coreset: "adult",
   performanceMeasure: {
     questionText: [
-      "The percentage of deliveries in the measurement period in which beneficiaries had received influenza and tetanus, diphtheria toxoids and acellular pertussis (Tdap) vaccinations.",
+      "The percentage of deliveries in the measurement period in which beneficiaries age 21 and older had received influenza and tetanus, diphtheria toxoids and acellular pertussis (Tdap) vaccinations.",
     ],
     categories,
     qualifiers,

--- a/services/ui-src/src/measures/2026/rateLabelText.ts
+++ b/services/ui-src/src/measures/2026/rateLabelText.ts
@@ -247,14 +247,19 @@ export const data = {
     "BCS-AD": {
         "qualifiers": [
             {
-                "label": "Ages 50 to 64",
-                "text": "Ages 50 to 64",
+                "label": "Ages 42 to 51",
+                "text": "Ages 42 to 51",
                 "id": "bfvp78"
+            },
+            {
+                "label": "Ages 52 to 64",
+                "text": "Ages 52 to 64",
+                "id": "vRqegW"
             },
             {
                 "label": "Ages 65 to 74",
                 "text": "Ages 65 to 74",
-                "id": "vRqegW"
+                "id": "RBUzwz"
             }
         ],
         "categories": [{"id":"xacc8a", "label": "", "text":""}]

--- a/services/ui-src/src/measures/2026/rateLabelText.ts
+++ b/services/ui-src/src/measures/2026/rateLabelText.ts
@@ -84,21 +84,34 @@ export const data = {
     "AIS-AD": {
         "qualifiers": [
             {
-                "label": "Ages 19 to 65",
-                "text": "Ages 19 to 65",
+                "label": "Ages 19 to 64",
+                "text": "Ages 19 to 64",
                 "id": "xz7TUf",
-                "excludeFromIds": ["HCnSrs", "B4SxBy"]
+                "excludeFromIds": ["HCnSrs", "B4SxBy", "8C1bKd"]
             },
             {
-                "label": "Ages 50 to 65",
-                "text": "Ages 50 to 65",
+                "label": "Ages 50 to 64",
+                "text": "Ages 50 to 64",
                 "id": "Fmvnxp",
-                "excludeFromIds": ["VZ0nYO", "2Bh7J8", "B4SxBy"]
+                "excludeFromIds": ["VZ0nYO", "2Bh7J8", "B4SxBy", "8C1bKd"]
             },
             {
-                "label": "Age 66 and older",
-                "text": "Age 66 and older",
+                "label": "Age 65 and older",
+                "text": "Age 65 and older",
                 "id": "VooeEU",
+                "excludeFromIds": ["8C1bKd"]
+            },
+            {
+                "label": "Ages 19 to 30",
+                "text": "Ages 19 to 30",
+                "id": "h4kJ2P",
+                "excludeFromIds": ["VZ0nYO", "2Bh7J8", "HCnSrs", "B4SxBy"]
+            },
+            {
+                "label": "Ages 31 to 59",
+                "text": "Ages 31 to 59",
+                "id": "mRzL8N",
+                "excludeFromIds": ["VZ0nYO", "2Bh7J8", "HCnSrs", "B4SxBy"]
             },
         ],
         "categories": [{
@@ -120,6 +133,11 @@ export const data = {
             "label": "Pneumococcal",
             "text": "Pneumococcal",
             "id": "B4SxBy",
+        },
+        {
+            "label": "Hepatitis B",
+            "text": "Hepatitis B",
+            "id": "8C1bKd",
         }]
     },
     "AMR-AD": {

--- a/services/ui-src/src/measures/2026/rateLabelText.ts
+++ b/services/ui-src/src/measures/2026/rateLabelText.ts
@@ -1255,8 +1255,8 @@ export const data = {
     "OEVP-AD": {
         "qualifiers": [
             {
-                "label": "Ages 21 to 44",
-                "text": "Ages 21 to 44",
+                "label": "Ages 21 through 44",
+                "text": "Ages 21 through 44",
                 "id": "wnh2qA",
             },
         ],

--- a/services/ui-src/src/measures/2026/rateLabelText.ts
+++ b/services/ui-src/src/measures/2026/rateLabelText.ts
@@ -1478,8 +1478,8 @@ export const data = {
                  "id": "e4G131"
              },
              {
-                 "label": "Follow-Up Positive Screen: Age 21 and Older",
-                 "text": "Follow-Up Positive Screen: Age 21 and Older",
+                 "label": "Follow-Up on Positive Screen: Age 21 and Older",
+                 "text": "Follow-Up on Positive Screen: Age 21 and Older",
                  "id": "hTfHWz"
              }
          ],

--- a/services/ui-src/src/measures/measureDescriptions.ts
+++ b/services/ui-src/src/measures/measureDescriptions.ts
@@ -543,7 +543,8 @@ export const measureDescriptions: MeasureList = {
     "PCR-AD": "Plan All-Cause Readmissions",
     "PDS-AD":
       "Postpartum Depression Screening and Follow-Up: Age 21 and Older (PDS-AD)",
-    "PND-AD": "Prenatal Depression Screening and Follow-Up: Age 21 and Older",
+    "PND-AD":
+      "Prenatal Depression Screening and Follow-Up: Age 21 and Older (PND-AD)",
     "PND-CH": "Prenatal Depression Screening and Follow-Up: Under Age 21",
     "PPC2-AD": "Prenatal and Postpartum Care: Age 21 and Over",
     "PQI01-AD": "PQI 01: Diabetes Short-Term Complications Admission Rate",

--- a/services/ui-src/src/measures/measureDescriptions.ts
+++ b/services/ui-src/src/measures/measureDescriptions.ts
@@ -517,7 +517,7 @@ export const measureDescriptions: MeasureList = {
     "CCS-AD": "Cervical Cancer Screening",
     "CCW-AD": "Contraceptive Care - All Women Ages 21 to 44",
     "CDF-AD": "Screening for Depression and Follow-Up Plan: Age 18 and Older",
-    "CHL-AD": "Chlamydia Screening in Women Ages 21 to 24",
+    "CHL-AD": "Chlamydia Screening: Ages 21 to 24",
     "COB-AD": "Concurrent Use of Opioids and Benzodiazepines",
     "COL-AD": "Colorectal Cancer Screening",
     "CPA-AD":

--- a/services/ui-src/src/measures/measureDescriptions.ts
+++ b/services/ui-src/src/measures/measureDescriptions.ts
@@ -541,7 +541,8 @@ export const measureDescriptions: MeasureList = {
     "OEVP-AD": "Oral Evaluation During Pregnancy: Ages 21 to 44",
     "OUD-AD": "Use of Pharmacotherapy for Opioid Use Disorder",
     "PCR-AD": "Plan All-Cause Readmissions",
-    "PDS-AD": "Postpartum Depression Screening and Follow-Up: Age 21 and Older",
+    "PDS-AD":
+      "Postpartum Depression Screening and Follow-Up: Age 21 and Older (PDS-AD)",
     "PND-AD": "Prenatal Depression Screening and Follow-Up: Age 21 and Older",
     "PND-CH": "Prenatal Depression Screening and Follow-Up: Under Age 21",
     "PPC2-AD": "Prenatal and Postpartum Care: Age 21 and Over",


### PR DESCRIPTION
### Description
Adult Core Set Measure Updates
AIS-AD, BCS-AD, CCS-AD, CHL-AD, COB-AD, FUH-AD, FUM-AD, OEVP-AD, PDS-AD, PND-AD, PRS-AD, PPC2-AD


### Related ticket(s)
CMDCT-5864

---
### How to test
**Deploy Link:** https://d1zrpblgdlbsg.cloudfront.net/

Navigate to each measure and see the updates

---
### Pre-review checklist
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary