### PR TITLE
[CMDCT-5842] Fix loading to initially blank page that requires a refresh

### DIFF
--- a/services/ui-src/src/App.tsx
+++ b/services/ui-src/src/App.tsx
@@ -11,7 +11,7 @@ import { fireTealiumPageView, makeMediaQueryClasses } from "utils";
 const App = () => {
   const mqClasses = makeMediaQueryClasses();
 
-  const { logout, user, showLocalLogins, loginWithIDM } = useUser();
+  const { logout, user, showLocalLogins, loginWithIDM, isLoading } = useUser();
   const { pathname, key } = useLocation();
 
   // fire tealium page view on route change
@@ -21,7 +21,8 @@ const App = () => {
 
   const authenticatedRoutes = (
     <>
-      {user && (
+      {isLoading && MeasuresLoading()}
+      {!isLoading && user && (
         <>
           <QMR.SkipNav />
           <QMR.ScrollToTop />
@@ -32,7 +33,9 @@ const App = () => {
           <QMR.Footer />
         </>
       )}
-      {!user && showLocalLogins && <LocalLogins loginWithIDM={loginWithIDM} />}
+      {!isLoading && !user && showLocalLogins && (
+        <LocalLogins loginWithIDM={loginWithIDM} />
+      )}
     </>
   );
 

--- a/services/ui-src/src/App.tsx
+++ b/services/ui-src/src/App.tsx
@@ -7,13 +7,11 @@ import { Suspense, useEffect } from "react";
 import { MeasuresLoading } from "views";
 import { Route, Routes, useLocation } from "react-router-dom";
 import { fireTealiumPageView, makeMediaQueryClasses } from "utils";
-import * as CUI from "@chakra-ui/react";
 
 const App = () => {
   const mqClasses = makeMediaQueryClasses();
 
-  const { logout, user, showLocalLogins, loginWithIDM, isLoading, authError } =
-    useUser();
+  const { logout, user, loginWithIDM, showLocalLogins } = useUser();
   const { pathname, key } = useLocation();
 
   // fire tealium page view on route change
@@ -23,8 +21,7 @@ const App = () => {
 
   const authenticatedRoutes = (
     <>
-      {isLoading && MeasuresLoading()}
-      {!isLoading && user && (
+      {user && (
         <>
           <QMR.SkipNav />
           <QMR.ScrollToTop />
@@ -35,28 +32,7 @@ const App = () => {
           <QMR.Footer />
         </>
       )}
-      {!isLoading && !user && showLocalLogins && (
-        <LocalLogins loginWithIDM={loginWithIDM} />
-      )}
-      {!isLoading && !user && !showLocalLogins && authError && (
-        <CUI.Container maxW="md" py="12" textAlign="center">
-          <CUI.Heading as="h1" size="lg" mb="4">
-            We couldn't sign you in
-          </CUI.Heading>
-          <CUI.Text mb="6">
-            Something went wrong while redirecting you to sign in. Please try
-            again.
-          </CUI.Text>
-          <CUI.Button colorScheme="teal" onClick={() => loginWithIDM()}>
-            Try Again
-          </CUI.Button>
-        </CUI.Container>
-      )}
-      {!isLoading &&
-        !user &&
-        !showLocalLogins &&
-        !authError &&
-        MeasuresLoading()}
+      {!user && showLocalLogins && <LocalLogins loginWithIDM={loginWithIDM} />}
     </>
   );
 

--- a/services/ui-src/src/App.tsx
+++ b/services/ui-src/src/App.tsx
@@ -7,11 +7,13 @@ import { Suspense, useEffect } from "react";
 import { MeasuresLoading } from "views";
 import { Route, Routes, useLocation } from "react-router-dom";
 import { fireTealiumPageView, makeMediaQueryClasses } from "utils";
+import * as CUI from "@chakra-ui/react";
 
 const App = () => {
   const mqClasses = makeMediaQueryClasses();
 
-  const { logout, user, showLocalLogins, loginWithIDM, isLoading } = useUser();
+  const { logout, user, showLocalLogins, loginWithIDM, isLoading, authError } =
+    useUser();
   const { pathname, key } = useLocation();
 
   // fire tealium page view on route change
@@ -36,6 +38,25 @@ const App = () => {
       {!isLoading && !user && showLocalLogins && (
         <LocalLogins loginWithIDM={loginWithIDM} />
       )}
+      {!isLoading && !user && !showLocalLogins && authError && (
+        <CUI.Container maxW="md" py="12" textAlign="center">
+          <CUI.Heading as="h1" size="lg" mb="4">
+            We couldn't sign you in
+          </CUI.Heading>
+          <CUI.Text mb="6">
+            Something went wrong while redirecting you to sign in. Please try
+            again.
+          </CUI.Text>
+          <CUI.Button colorScheme="teal" onClick={() => loginWithIDM()}>
+            Try Again
+          </CUI.Button>
+        </CUI.Container>
+      )}
+      {!isLoading &&
+        !user &&
+        !showLocalLogins &&
+        !authError &&
+        MeasuresLoading()}
     </>
   );
 

--- a/services/ui-src/src/hooks/authHooks/userContext.tsx
+++ b/services/ui-src/src/hooks/authHooks/userContext.tsx
@@ -3,7 +3,6 @@ import { createContext } from "react";
 export interface UserContextInterface {
   user?: any;
   showLocalLogins?: boolean;
-  authError?: boolean;
   logout: () => Promise<void>;
   loginWithIDM: () => Promise<void>;
   isStateUser: boolean;

--- a/services/ui-src/src/hooks/authHooks/userContext.tsx
+++ b/services/ui-src/src/hooks/authHooks/userContext.tsx
@@ -4,6 +4,7 @@ export interface UserContextInterface {
   user?: any;
   showLocalLogins?: boolean;
   isLoading?: boolean;
+  authError?: boolean;
   logout: () => Promise<void>;
   loginWithIDM: () => Promise<void>;
   isStateUser: boolean;

--- a/services/ui-src/src/hooks/authHooks/userContext.tsx
+++ b/services/ui-src/src/hooks/authHooks/userContext.tsx
@@ -3,6 +3,7 @@ import { createContext } from "react";
 export interface UserContextInterface {
   user?: any;
   showLocalLogins?: boolean;
+  isLoading?: boolean;
   logout: () => Promise<void>;
   loginWithIDM: () => Promise<void>;
   isStateUser: boolean;

--- a/services/ui-src/src/hooks/authHooks/userContext.tsx
+++ b/services/ui-src/src/hooks/authHooks/userContext.tsx
@@ -3,7 +3,6 @@ import { createContext } from "react";
 export interface UserContextInterface {
   user?: any;
   showLocalLogins?: boolean;
-  isLoading?: boolean;
   authError?: boolean;
   logout: () => Promise<void>;
   loginWithIDM: () => Promise<void>;

--- a/services/ui-src/src/hooks/authHooks/userProvider.tsx
+++ b/services/ui-src/src/hooks/authHooks/userProvider.tsx
@@ -15,16 +15,14 @@ interface Props {
 }
 
 const authenticateWithIDM = async () => {
-  // Clear any stale cached tokens / OAuth state before initiating the
-  // redirect. If a previous session left expired tokens or stale PKCE
+  // Clear any stale cached tokens before initiating the
+  // redirect. If a previous session left expired tokens or stale
   // values in localStorage, signInWithRedirect can fail silently or
-  // produce an OAuth state mismatch when IDM redirects back. This runs
-  // in all environments because every caller of this function is about
-  // to redirect away — we never call it on a user with a valid session.
+  // produce an OAuth state mismatch when IDM redirects back.
   try {
     await signOut({ global: false });
   } catch {
-    // Ignore — we only care about clearing local state, not server-side.
+    // Ignoring as we only care about clearing local tokens
   }
   await signInWithRedirect({ provider: { custom: "Okta" } });
 };
@@ -38,7 +36,6 @@ export const UserProvider = ({ children }: Props) => {
   const [isStateUser, setIsStateUser] = useState<boolean>(false);
   const [userState, setUserState] = useState<any>("");
   const [showLocalLogins, setShowLocalLogins] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
   const [authError, setAuthError] = useState(false);
 
   const logout = useCallback(async () => {
@@ -59,7 +56,6 @@ export const UserProvider = ({ children }: Props) => {
 
     // Authenticate
     try {
-      setIsLoading(true);
       const tokens = (await fetchAuthSession()).tokens;
       if (!tokens?.idToken) {
         throw new Error("Missing tokens auth session.");
@@ -84,17 +80,12 @@ export const UserProvider = ({ children }: Props) => {
         try {
           await authenticateWithIDM();
         } catch (error) {
-          // signInWithRedirect failed before navigating away (network,
-          // config, etc.). Surface an error so the user isn't stuck on
-          // a blank spinner with no recovery path.
           console.log("Error initiating IDM sign-in:", error);
           setAuthError(true);
         }
       } else {
         setShowLocalLogins(true);
       }
-    } finally {
-      setIsLoading(false);
     }
   }, [isProduction, location]);
 
@@ -118,7 +109,6 @@ export const UserProvider = ({ children }: Props) => {
       user,
       logout,
       showLocalLogins,
-      isLoading,
       authError,
       loginWithIDM,
       isStateUser,
@@ -129,8 +119,6 @@ export const UserProvider = ({ children }: Props) => {
       user,
       logout,
       showLocalLogins,
-      isLoading,
-      authError,
       loginWithIDM,
       isStateUser,
       userState,

--- a/services/ui-src/src/hooks/authHooks/userProvider.tsx
+++ b/services/ui-src/src/hooks/authHooks/userProvider.tsx
@@ -15,6 +15,17 @@ interface Props {
 }
 
 const authenticateWithIDM = async () => {
+  // Clear any stale cached tokens / OAuth state before initiating the
+  // redirect. If a previous session left expired tokens or stale PKCE
+  // values in localStorage, signInWithRedirect can fail silently or
+  // produce an OAuth state mismatch when IDM redirects back. This runs
+  // in all environments because every caller of this function is about
+  // to redirect away — we never call it on a user with a valid session.
+  try {
+    await signOut({ global: false });
+  } catch {
+    // Ignore — we only care about clearing local state, not server-side.
+  }
   await signInWithRedirect({ provider: { custom: "Okta" } });
 };
 
@@ -28,6 +39,7 @@ export const UserProvider = ({ children }: Props) => {
   const [userState, setUserState] = useState<any>("");
   const [showLocalLogins, setShowLocalLogins] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [authError, setAuthError] = useState(false);
 
   const logout = useCallback(async () => {
     try {
@@ -69,7 +81,15 @@ export const UserProvider = ({ children }: Props) => {
       });
     } catch {
       if (isProduction) {
-        await authenticateWithIDM();
+        try {
+          await authenticateWithIDM();
+        } catch (error) {
+          // signInWithRedirect failed before navigating away (network,
+          // config, etc.). Surface an error so the user isn't stuck on
+          // a blank spinner with no recovery path.
+          console.log("Error initiating IDM sign-in:", error);
+          setAuthError(true);
+        }
       } else {
         setShowLocalLogins(true);
       }
@@ -83,18 +103,39 @@ export const UserProvider = ({ children }: Props) => {
     checkAuthState();
   }, [location, checkAuthState]);
 
+  const loginWithIDM = useCallback(async () => {
+    setAuthError(false);
+    try {
+      await authenticateWithIDM();
+    } catch (error) {
+      console.log("Error initiating IDM sign-in:", error);
+      setAuthError(true);
+    }
+  }, []);
+
   const values: UserContextInterface = useMemo(
     () => ({
       user,
       logout,
       showLocalLogins,
       isLoading,
-      loginWithIDM: authenticateWithIDM,
+      authError,
+      loginWithIDM,
       isStateUser,
       userState,
       userRole,
     }),
-    [user, logout, showLocalLogins, isLoading, isStateUser, userState, userRole]
+    [
+      user,
+      logout,
+      showLocalLogins,
+      isLoading,
+      authError,
+      loginWithIDM,
+      isStateUser,
+      userState,
+      userRole,
+    ]
   );
 
   return <UserContext.Provider value={values}>{children}</UserContext.Provider>;

--- a/services/ui-src/src/hooks/authHooks/userProvider.tsx
+++ b/services/ui-src/src/hooks/authHooks/userProvider.tsx
@@ -27,6 +27,7 @@ export const UserProvider = ({ children }: Props) => {
   const [isStateUser, setIsStateUser] = useState<boolean>(false);
   const [userState, setUserState] = useState<any>("");
   const [showLocalLogins, setShowLocalLogins] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   const logout = useCallback(async () => {
     try {
@@ -46,6 +47,7 @@ export const UserProvider = ({ children }: Props) => {
 
     // Authenticate
     try {
+      setIsLoading(true);
       const tokens = (await fetchAuthSession()).tokens;
       if (!tokens?.idToken) {
         throw new Error("Missing tokens auth session.");
@@ -71,6 +73,8 @@ export const UserProvider = ({ children }: Props) => {
       } else {
         setShowLocalLogins(true);
       }
+    } finally {
+      setIsLoading(false);
     }
   }, [isProduction, location]);
 
@@ -84,12 +88,13 @@ export const UserProvider = ({ children }: Props) => {
       user,
       logout,
       showLocalLogins,
+      isLoading,
       loginWithIDM: authenticateWithIDM,
       isStateUser,
       userState,
       userRole,
     }),
-    [user, logout, showLocalLogins, isStateUser, userState, userRole]
+    [user, logout, showLocalLogins, isLoading, isStateUser, userState, userRole]
   );
 
   return <UserContext.Provider value={values}>{children}</UserContext.Provider>;

--- a/services/ui-src/src/hooks/authHooks/userProvider.tsx
+++ b/services/ui-src/src/hooks/authHooks/userProvider.tsx
@@ -36,7 +36,6 @@ export const UserProvider = ({ children }: Props) => {
   const [isStateUser, setIsStateUser] = useState<boolean>(false);
   const [userState, setUserState] = useState<any>("");
   const [showLocalLogins, setShowLocalLogins] = useState(false);
-  const [authError, setAuthError] = useState(false);
 
   const logout = useCallback(async () => {
     try {
@@ -81,7 +80,6 @@ export const UserProvider = ({ children }: Props) => {
           await authenticateWithIDM();
         } catch (error) {
           console.log("Error initiating IDM sign-in:", error);
-          setAuthError(true);
         }
       } else {
         setShowLocalLogins(true);
@@ -95,12 +93,10 @@ export const UserProvider = ({ children }: Props) => {
   }, [location, checkAuthState]);
 
   const loginWithIDM = useCallback(async () => {
-    setAuthError(false);
     try {
       await authenticateWithIDM();
     } catch (error) {
       console.log("Error initiating IDM sign-in:", error);
-      setAuthError(true);
     }
   }, []);
 
@@ -109,7 +105,6 @@ export const UserProvider = ({ children }: Props) => {
       user,
       logout,
       showLocalLogins,
-      authError,
       loginWithIDM,
       isStateUser,
       userState,


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
You've seen it. The white screen when you load up one of our apps requiring you to hard refresh the page to get your to the sign-in page. Well no longer! This multi-year bugs reign is at an end.

The issue, at least from how I understand it, is that users returning to our apps after ~24h saw a blank white screen because their refresh token had expired but stale auth state was still cached in localStorage. Our authentication process now calls `signOut({ global: false })` before redirecting us and signing in. This wipes the expired tokens and stale values from localStorage, so the authentication flow starts from the beginning again. Should mention, that signOut call is only made when a user’s auth is already failing so this will not impact users who have valid/fresh credentials.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5842

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Try signing into there, then close the browser tab and check back like 1 day + 30 mins from now (Can be any time after 24 hours). Yyou also need to make sure you don't open anything else related to QMR during this timeframe as that'll reset your credentials so a weekend is a good time to test! 

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment
