### PR TITLE
2026 - "Does this denominator..." Validation

### DIFF
--- a/services/ui-src/src/measures/2026/validationTemplate.tsx
+++ b/services/ui-src/src/measures/2026/validationTemplate.tsx
@@ -425,6 +425,8 @@ export const validationTemplate = (
         return GV.validateAtLeastOneDefinitionOfPopulation(data);
       case "validateHybridMeasurePopulation":
         return GV.validateHybridMeasurePopulation(data);
+      case "validateDefinitionOfDenominatorNoExplain":
+        return GV.validateDefinitionOfDenominatorNoExplain(data);
       case "validateEqualQualifierOfCategoryDenominatorsPM":
         const sets = PMD.override?.validateEqualQualifierOfCategoryDenominators;
         return sets?.flatMap((set) =>
@@ -477,6 +479,9 @@ export const validationTemplate = (
   )) {
     errorArray.push(...(validationList(validation) ?? []));
   }
+
+  // 2026-only denominator "No" follow-up validation
+  errorArray.push(...GV.validateDefinitionOfDenominatorNoExplain(data));
 
   errorArray.push(
     ...GV.omsValidations({

--- a/services/ui-src/src/measures/2026/validationTemplate.tsx
+++ b/services/ui-src/src/measures/2026/validationTemplate.tsx
@@ -480,7 +480,6 @@ export const validationTemplate = (
     errorArray.push(...(validationList(validation) ?? []));
   }
 
-  // 2026-only denominator "No" follow-up validation
   errorArray.push(...GV.validateDefinitionOfDenominatorNoExplain(data));
 
   errorArray.push(

--- a/services/ui-src/src/measures/2026/validationTemplate.tsx
+++ b/services/ui-src/src/measures/2026/validationTemplate.tsx
@@ -425,8 +425,6 @@ export const validationTemplate = (
         return GV.validateAtLeastOneDefinitionOfPopulation(data);
       case "validateHybridMeasurePopulation":
         return GV.validateHybridMeasurePopulation(data);
-      case "validateDefinitionOfDenominatorNoExplain":
-        return GV.validateDefinitionOfDenominatorNoExplain(data);
       case "validateEqualQualifierOfCategoryDenominatorsPM":
         const sets = PMD.override?.validateEqualQualifierOfCategoryDenominators;
         return sets?.flatMap((set) =>
@@ -480,6 +478,7 @@ export const validationTemplate = (
     errorArray.push(...(validationList(validation) ?? []));
   }
 
+  // Run for all measures: if the denominator does not represent the total measure-eligible population, require follow-up details.
   errorArray.push(...GV.validateDefinitionOfDenominatorNoExplain(data));
 
   errorArray.push(

--- a/services/ui-src/src/shared/globalValidations/index.ts
+++ b/services/ui-src/src/shared/globalValidations/index.ts
@@ -33,6 +33,7 @@ export * from "shared/globalValidations/validateNDRTotalsMatchSum";
 export * from "shared/globalValidations/validateAtLeastOneDeviationFieldFilled";
 export * from "shared/globalValidations/validateCollecting";
 export * from "shared/globalValidations/validateOneQualRateLessThanOrEqualToOtherQualRates";
+export * from "shared/globalValidations/validateDefinitionOfDenominatorNoExplain";
 
 // PCR-XX Specific Validations
 export { PCRatLeastOneRateComplete } from "shared/globalValidations/PCRValidations/PCRatLeastOneRateComplete";

--- a/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.test.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.test.ts
@@ -1,0 +1,47 @@
+import * as DC from "dataConstants";
+import { testFormData } from "./../testHelpers/_testFormData";
+import { validateDefinitionOfDenominatorNoExplain } from ".";
+
+describe("validateDefinitionOfDenominatorNoExplain", () => {
+  let formData: any;
+
+  const expectedError = {
+    errorLocation: "Denominator Includes Total Measure-Eligible Population",
+    errorMessage:
+      "Complete the additional fields to explain which populations are excluded and why and, if possible, estimate the size of the excluded measure-eligible population.",
+  };
+
+  const setValues = (
+    totalTechSpec: string,
+    explanation: string,
+    excludedPopSize: string
+  ) => {
+    formData[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC] = totalTechSpec;
+    formData[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_EXPLAIN] = explanation;
+    formData[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_SIZE] = excludedPopSize;
+  };
+
+  beforeEach(() => {
+    formData = JSON.parse(JSON.stringify(testFormData));
+  });
+
+  it("returns no errors when total tech spec is yes", () => {
+    setValues(DC.YES, "", "");
+    expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([]);
+  });
+
+  it("returns no errors when total tech spec is no and both follow-up fields are filled", () => {
+    setValues(DC.NO, "Population A is excluded due to missing claims", "123");
+    expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([]);
+  });
+
+  it.each([
+    ["explanation is blank", "", "123"],
+    ["excluded population size is blank", "Population A is excluded", ""],
+  ])("returns an error when %s", (_case, explanation, excludedPopSize) => {
+    setValues(DC.NO, explanation, excludedPopSize);
+    expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([
+      expectedError,
+    ]);
+  });
+});

--- a/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.ts
@@ -2,7 +2,11 @@ import * as DC from "dataConstants";
 
 export const validateDefinitionOfDenominatorNoExplain = (data: any) => {
   if (data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC] !== DC.NO) return [];
-  if (data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_EXPLAIN]) return [];
+  if (
+    data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_EXPLAIN] &&
+    data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_SIZE]
+  )
+    return [];
 
   return [
     {

--- a/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.ts
@@ -1,21 +1,8 @@
 import * as DC from "dataConstants";
-import { DefaultFormData } from "shared/types/FormData";
 
-export const validateDefinitionOfDenominatorNoExplain = (
-  data: DefaultFormData
-) => {
-  const isNo =
-    data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC as keyof DefaultFormData] ===
-    DC.NO;
-
-  if (!isNo) return [];
-
-  const explanation =
-    data[
-      DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_EXPLAIN as keyof DefaultFormData
-    ];
-
-  if (explanation) return [];
+export const validateDefinitionOfDenominatorNoExplain = (data: any) => {
+  if (data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC] !== DC.NO) return [];
+  if (data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_EXPLAIN]) return [];
 
   return [
     {

--- a/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.ts
@@ -1,6 +1,9 @@
 import * as DC from "dataConstants";
+import * as Types from "shared/types";
 
-export const validateDefinitionOfDenominatorNoExplain = (data: any) => {
+export const validateDefinitionOfDenominatorNoExplain = (
+  data: Types.DefinitionOfPopulation
+) => {
   if (data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC] !== DC.NO) return [];
   if (
     data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_EXPLAIN] &&

--- a/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.ts
@@ -1,0 +1,27 @@
+import * as DC from "dataConstants";
+import { DefaultFormData } from "shared/types/FormData";
+
+export const validateDefinitionOfDenominatorNoExplain = (
+  data: DefaultFormData
+) => {
+  const isNo =
+    data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC as keyof DefaultFormData] ===
+    DC.NO;
+
+  if (!isNo) return [];
+
+  const explanation =
+    data[
+      DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_EXPLAIN as keyof DefaultFormData
+    ];
+
+  if (explanation) return [];
+
+  return [
+    {
+      errorLocation: "Denominator Includes Total Measure-Eligible Population",
+      errorMessage:
+        "Complete the additional fields to explain which populations are excluded and why and, if possible, estimate the size of the excluded measure-eligible population.",
+    },
+  ];
+};

--- a/services/ui-src/src/shared/types/MeasureTemplate.tsx
+++ b/services/ui-src/src/shared/types/MeasureTemplate.tsx
@@ -75,6 +75,7 @@ export const validationFunctions = [
   "validateCollecting",
   "validateOneQualRateLessThanOrEqualToOtherQualRatesOMS",
   "validateOneQualRateLessThanOrEqualToOtherQualRatesPM",
+  "validateDefinitionOfDenominatorNoExplain",
 ] as const;
 
 export type ValidationFunction = (typeof validationFunctions)[number];

--- a/services/ui-src/src/shared/types/MeasureTemplate.tsx
+++ b/services/ui-src/src/shared/types/MeasureTemplate.tsx
@@ -75,7 +75,6 @@ export const validationFunctions = [
   "validateCollecting",
   "validateOneQualRateLessThanOrEqualToOtherQualRatesOMS",
   "validateOneQualRateLessThanOrEqualToOtherQualRatesPM",
-  "validateDefinitionOfDenominatorNoExplain",
 ] as const;
 
 export type ValidationFunction = (typeof validationFunctions)[number];


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
* Add validation if user selects no for "Does this denominator represent your total measure-eligible population..." and doesn't specify why

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6059

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://dlu4yv3s5tkn8.cloudfront.net/
* Fill out the form and choose "No" for "Does this denominator represent your total measure-eligible population..." and leave the the either section empty
* See the validation triggered when click `validate measure`
<img width="1313" height="353" alt="Screenshot 2026-05-26 at 10 30 06 AM" src="https://github.com/user-attachments/assets/edede04c-9635-493e-8457-0b02e4c003ad" />


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
