### PR TITLE
fix modifyMissingLabel bug for 2026+

### DIFF
--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
@@ -30,7 +30,7 @@ export const OMSData = (
       return version === "1997-omb" ? omb1997() : omb2024();
     default: // 2026 and forward
       if (version === "not-reporting") {
-        return removeRaceAndEthnicity(modifyMissingLabel(strat2026(coreSetId)));
+        return modifyMissingLabel(removeRaceAndEthnicity(strat2026(coreSetId)));
       }
       return modifyMissingLabel(
         version === "1997-omb" ? omb1997() : strat2026(coreSetId)

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
@@ -28,20 +28,13 @@ export const OMSData = (
       return omb1997();
     case 2025:
       return version === "1997-omb" ? omb1997() : omb2024();
-    case 2026:
-      if (version === "1997-omb") {
-        return omb1997();
-      }
+    default: // 2026 and forward
       if (version === "not-reporting") {
-        return removeRaceAndEthnicity(strat2026(coreSetId));
+        return removeRaceAndEthnicity(modifyMissingLabel(strat2026(coreSetId)));
       }
-      return strat2026(coreSetId);
-    default:
-      if (version === "not-reporting") {
-        return removeRaceAndEthnicity(modifyMissingLabel(omb2024()));
-      }
-
-      return modifyMissingLabel(version === "1997-omb" ? omb1997() : omb2024());
+      return modifyMissingLabel(
+        version === "1997-omb" ? omb1997() : strat2026(coreSetId)
+      );
   }
 };
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->

Fixing a bug that Ben identified with the missing categories labels for stratification.  We opted to remove the 2026 conditional from the `OMSData` function logic for right now since 2026 is our current default case.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6058

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

Env link: https://d11fnppapi41s5.cloudfront.net/

1. Fill in a measure and select that Yes you are reporting stratification
2. Expand the stratification sections and look for the Missing or other option
3. Validate that it has (Race) or (Ethnicity) or any of the other category labels appended in parenthesis for the Missing or other options for each available section


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
