### PR TITLE
[CMDCT-6157] Remove Audit Qualifier Question for 2026

### DIFF
--- a/services/ui-src/src/shared/Qualifiers/index.test.tsx
+++ b/services/ui-src/src/shared/Qualifiers/index.test.tsx
@@ -2,6 +2,10 @@ import { screen } from "@testing-library/react";
 import { Qualifier } from ".";
 import { renderWithHookForm } from "utils";
 import { useApiMock } from "utils/testUtils/useApiMock";
+import { getMeasureYear } from "utils/getMeasureYear";
+
+jest.mock("utils/getMeasureYear");
+const mockGetMeasureYear = getMeasureYear as jest.Mock;
 
 jest.mock("react-router-dom", () => ({
   useParams: jest.fn().mockReturnValue({ coreSetId: "ACSC" }),
@@ -10,6 +14,7 @@ jest.mock("react-router-dom", () => ({
 describe("Test Qualifier", () => {
   beforeEach(() => {
     useApiMock({});
+    mockGetMeasureYear.mockReturnValue(2026);
   });
   it("Qualifier renders", () => {
     renderWithHookForm(
@@ -23,5 +28,24 @@ describe("Test Qualifier", () => {
         "Please report data on Separate CHIP (Title XXI) for the Adult Core Set on this page. This is not a mandatory requirement."
       )
     ).toBeVisible();
+  });
+
+  it("does not render the Audit or Validation of Measures question for 2026", () => {
+    renderWithHookForm(
+      <Qualifier name={"mock-name"} year={"2026"} measureId={"BCS-AD"} />
+    );
+    expect(
+      screen.queryByText("Audit or Validation of Measures")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the Audit or Validation of Measures question for years prior to 2026", () => {
+    mockGetMeasureYear.mockReturnValue(2025);
+    renderWithHookForm(
+      <Qualifier name={"mock-name"} year={"2025"} measureId={"BCS-AD"} />
+    );
+    expect(
+      screen.getByText("Audit or Validation of Measures")
+    ).toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/shared/Qualifiers/index.tsx
+++ b/services/ui-src/src/shared/Qualifiers/index.tsx
@@ -8,6 +8,7 @@ import { validationFunctions } from "shared/Qualifiers/validationFunctions";
 import { DeliverySystems } from "shared/Qualifiers/deliverySystems";
 import { useParams } from "react-router-dom";
 import * as Types from "types";
+import { featuresByYear } from "utils/featuresByYear";
 
 export const Qualifier = ({
   setValidationFunctions,
@@ -60,7 +61,9 @@ export const Qualifier = ({
           )}
           <DeliverySystems data={data} year={year} />
           <CUI.Spacer flex={2} />
-          <Common.Audit type={type} year={year} />
+          {featuresByYear.displayAuditOrValidation && (
+            <Common.Audit type={type} year={year} />
+          )}
           {type !== "HH" && <Common.ExternalContractor />}
         </CUI.OrderedList>
       </CUI.VStack>

--- a/services/ui-src/src/utils/featuresByYear.ts
+++ b/services/ui-src/src/utils/featuresByYear.ts
@@ -191,4 +191,12 @@ export const featuresByYear = {
   get useStratificationYesNo() {
     return getMeasureYear() >= 2026;
   },
+
+  /**
+   * In 2026, CMS removed the "Audit or Validation of Measures" question
+   * from the Child, Adult, and Health Home Qualifier forms.
+   */
+  get displayAuditOrValidation() {
+    return getMeasureYear() < 2026;
+  },
 };


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
CMS would like to remove the Audit or Validation of Measures question in the Qualifier Questions. This is number 3 in the Child and Adult Qualifier Questions (both Medicaid and Separate CHIP) and number 4 in the Health Home Qualifier Questions. For the Child and Adult Qualifier Questions, this will require renumbering the existing questions. We would like to retain all other questions. So this does just that!


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6157

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Sign in as stateuser4 (Has health home qualifier questions)
- Make sure the core set is set to 2026
- Open one of the Child or Adult Qualifier Questions 
- Click Enter Qualifier Questions
- See that the audit question is removed :smile:
- Feel free to check out the other Child or Adult Qualifier Questions too!
- Set the core set year to 2025
- Repeat the process and see that the audit question is still there
- Now do the same thing, but after you've added the health home core set and you'll see its gone from that qualifier question as well

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [x] Product: This work has been reviewed and approved by product owner, if necessary