### PR TITLE
[QMR] 2025/2026 PDF

### DIFF
--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -507,9 +507,8 @@ export const MeasureWrapper = ({
                   {stratificationRequired?.includes(coreSet) && (
                     <CUI.Box mb="1rem">
                       <Alert heading="Reminder: Measure Stratification Required">
-                        <CUI.Text>
-                          {`For ${year} Core Sets reporting, states are expected to report stratified data for this measure.`}
-                        </CUI.Text>
+                        For {year} Core Sets reporting, states are expected to
+                        report stratified data for this measure.
                       </Alert>
                     </CUI.Box>
                   )}

--- a/services/ui-src/src/components/PrintableMeasureWrapper/index.test.tsx
+++ b/services/ui-src/src/components/PrintableMeasureWrapper/index.test.tsx
@@ -69,4 +69,24 @@ describe("Test PrintableMeasureWrapper Component", () => {
 
     expect(screen.queryByText("mock measure")).not.toBeInTheDocument();
   });
+
+  it("renders stratification reminder when required for the core set", () => {
+    mockUseParam.mockReturnValue({ coreSetId: "CCSM", state: "MA" });
+    renderWithHookForm(
+      <PrintableMeasureWrapper
+        measure={mockMeasure}
+        name={"AAB-CH"}
+        year={"2026"}
+        measureId={"AAB-CH"}
+        measureData={{
+          ...mockMeasureData,
+          stratificationRequired: ["CCSM"],
+        }}
+      ></PrintableMeasureWrapper>
+    );
+
+    expect(
+      screen.getByText("Reminder: Measure Stratification Required")
+    ).toBeInTheDocument();
+  });
 });

--- a/services/ui-src/src/components/PrintableMeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/PrintableMeasureWrapper/index.tsx
@@ -19,6 +19,7 @@ import { CoreSetAbbr } from "types";
 import { measureDescriptions } from "measures/measureDescriptions";
 import SharedContext from "shared/SharedContext";
 import * as Labels from "labels/Labels";
+import { Alert } from "@cmsgov/design-system";
 
 const LastModifiedBy = ({ user }: { user: string | undefined }) => {
   if (!user) return null;
@@ -114,7 +115,6 @@ export const PrintableMeasureWrapper = ({
   const params = useParams();
 
   const methods = useForm({
-    shouldUnregister: true,
     mode: "all",
     defaultValues: measureData?.data ?? undefined,
     criteriaMode: "firstError",
@@ -136,10 +136,8 @@ export const PrintableMeasureWrapper = ({
     ) {
       methods.reset(
         params.coreSetId
-          ? defaultData?.[
-              (params.coreSetId?.split("_")?.[0] ??
-                params.coreSetId) as CoreSetAbbr
-            ]?.formData
+          ? defaultData?.[params.coreSetId.split("_")[0] as CoreSetAbbr]
+              ?.formData
           : undefined
       );
     }
@@ -150,6 +148,8 @@ export const PrintableMeasureWrapper = ({
   if (!params.coreSetId || !params.state) {
     return null;
   }
+
+  const coreSet = params.coreSetId.split("_")[0] as CoreSetAbbr;
 
   const foundMeasureDescription =
     measureDescriptions[measureData?.year]?.[measureData?.measure] ||
@@ -185,6 +185,15 @@ export const PrintableMeasureWrapper = ({
           >
             {measureData.detailedDescription}
           </CUI.Text>
+        </CUI.Box>
+      )}
+      {measureData?.stratificationRequired?.includes(coreSet) && (
+        <CUI.Box mb="1rem">
+          <Alert heading="Reminder: Measure Stratification Required">
+            <CUI.Text>
+              {`For ${year} Core Sets reporting, states are expected to report stratified data for this measure.`}
+            </CUI.Text>
+          </Alert>
         </CUI.Box>
       )}
       <FormProvider {...methods}>

--- a/services/ui-src/src/components/PrintableMeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/PrintableMeasureWrapper/index.tsx
@@ -190,9 +190,8 @@ export const PrintableMeasureWrapper = ({
       {measureData?.stratificationRequired?.includes(coreSet) && (
         <CUI.Box mb="1rem">
           <Alert heading="Reminder: Measure Stratification Required">
-            <CUI.Text>
-              {`For ${year} Core Sets reporting, states are expected to report stratified data for this measure.`}
-            </CUI.Text>
+            For {year} Core Sets reporting, states are expected to report
+            stratified data for this measure.
           </Alert>
         </CUI.Box>
       )}

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -110,6 +110,7 @@ export const applyPrinceSpecificCss = (): HTMLStyleElement => {
       ********* */ ""
     }
     .chakra-button { background: var(--chakra-colors-gray-100) !important; margin: 16px 8px }
+    .chakra-accordion__button { display: flex !important; visibility: visible !important; }
     .chakra-link { color: var(--chakra-colors-blue-600) !important; }
     .chakra-link * { color: blue !important; }
 


### PR DESCRIPTION
### Description
The Optional Measure Stratification (OMS) section and its content were not rendering in the PDF export for 2025/2026 measures. Additionally, the "Reminder: Measure Stratification Required" alert was missing from the PDF view entirely.

1. _OMS section not rendering in PDF (PrintableMeasureWrapper)_
shouldUnregister: true was set on the useForm instance. When MeasureStrat briefly unmounted (during the reset cycle triggered by showOptionalMeasureStrat becoming false), react-hook-form cleared the OptionalMeasureStratification.version field value from the store. On remount, watch() returned undefined for version, so MeasureStrat's useEffect never set version state, keeping hasSelectedVersion = false and preventing the Stratification component from rendering at all.
**Fix:** Removed shouldUnregister: true (defaulting to false), so field values are preserved across remounts.

2. _OMS accordion labels hidden in generated PDF (ExportAll/util.tsx)_
applyPrinceSpecificCss applies button { display: none !important } to hide interactive buttons from the PDF. Chakra's AccordionButton renders as a <button> element, so the accordion header labels ("Foster Care", "Race", "In foster care during the measurement period", etc.) were also hidden. Because .chakra-accordion__button (class selector, specificity 0-1-0) outranks button (type selector, 0-0-1), even with !important, an override restores accordion button visibility. 
**Fix:** Added .chakra-accordion__button { display: flex !important; visibility: visible !important; } to the PDF-specific stylesheet.

3. _Stratification reminder alert missing from PDF (PrintableMeasureWrapper)_
The "Reminder: Measure Stratification Required" alert was only rendered in the measure's interactive wrapper, not in PrintableMeasureWrapper used for PDF export.
**Fix:** Added the alert to PrintableMeasureWrapper, checking measureData.stratificationRequired against the current core set.

4. _Dead code cleanup (PrintableMeasureWrapper)_
Simplified the coreSetId parsing fallback chain params.coreSetId?.split("_")?.[0] ?? params.coreSetId ?? "ACS" to params.coreSetId.split("_")[0], since the !params.coreSetId guard above makes optional chaining and the fallbacks unnecessary.

**Background:** 
Ensure all new sections of the stratification section are appearing in the PDF for QMR.

**Overview:**
Update the PDF generated for QMR to include all new Stratification Sections
This update is for 2025 and 2026
This PDF update should include:
New Yes/No stratification section
New question about Race and Ethnicity stratification type.
Stratification section headers
New Foster Care and Expanded Medicaid sections


### Related ticket(s)
CMDCT-6113

---
### How to test
**Deploy Link:** https://d12x4oc2u2w6zo.cloudfront.net/

1. Fill out stratification data on a few measures so that values show up on PDF
2. Go back to home page and click on 3 dots to the right of the Core Set whose measures you filled out
3. Click on "Export"
      <img width="250" height="300" alt="Screenshot 2026-06-17 at 8 23 36 PM" src="https://github.com/user-attachments/assets/597d0c45-3277-4fb2-a6fc-64a04252ef8a" />
4. Click on Giant "PRINT PDF" button (Note: Make sure if you have a ad pop up blocker, you pause it for the PDF to download correctly)
     <img width="400" height="100" alt="PRINT PDF button" src="https://github.com/user-attachments/assets/19661cd5-988a-4a5a-8c9c-7247c2b6a6a7" />
5. Confirm PDF view shows stratification data with headers



### Notes


---
### Pre-review checklist
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary