### PR TITLE
[CMDCT-6160] Update Age 21 and Over to Age 21 and Older

### DIFF
--- a/services/ui-src/src/measures/measureDescriptions.ts
+++ b/services/ui-src/src/measures/measureDescriptions.ts
@@ -546,7 +546,7 @@ export const measureDescriptions: MeasureList = {
     "PND-AD":
       "Prenatal Depression Screening and Follow-Up: Age 21 and Older (PND-AD)",
     "PND-CH": "Prenatal Depression Screening and Follow-Up: Under Age 21",
-    "PPC2-AD": "Prenatal and Postpartum Care: Age 21 and Over",
+    "PPC2-AD": "Prenatal and Postpartum Care: Age 21 and Older",
     "PQI01-AD": "PQI 01: Diabetes Short-Term Complications Admission Rate",
     "PQI05-AD":
       "PQI 05: Chronic Obstructive Pulmonary Disease (COPD) or Asthma in Older Adults Admission Rate",


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
This is for measure PPC2-AD. It simply changes the title :) 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6160

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Log in and navigate to a 2026 Adult measure list
- Find PPC2-AD — the measure name at the top of the page should read "Prenatal and Postpartum Care: Age 21 and Older"
- Optionally verify a 2024 or 2025 PPC2-AD still reads "Age 21 and Over"

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary