### PR TITLE
[CMDCT-6161] Remove extra abbreviations

### DIFF
--- a/services/ui-src/src/measures/measureDescriptions.ts
+++ b/services/ui-src/src/measures/measureDescriptions.ts
@@ -541,10 +541,8 @@ export const measureDescriptions: MeasureList = {
     "OEVP-AD": "Oral Evaluation During Pregnancy: Ages 21 to 44",
     "OUD-AD": "Use of Pharmacotherapy for Opioid Use Disorder",
     "PCR-AD": "Plan All-Cause Readmissions",
-    "PDS-AD":
-      "Postpartum Depression Screening and Follow-Up: Age 21 and Older (PDS-AD)",
-    "PND-AD":
-      "Prenatal Depression Screening and Follow-Up: Age 21 and Older (PND-AD)",
+    "PDS-AD": "Postpartum Depression Screening and Follow-Up: Age 21 and Older",
+    "PND-AD": "Prenatal Depression Screening and Follow-Up: Age 21 and Older",
     "PND-CH": "Prenatal Depression Screening and Follow-Up: Under Age 21",
     "PPC2-AD": "Prenatal and Postpartum Care: Age 21 and Over",
     "PQI01-AD": "PQI 01: Diabetes Short-Term Complications Admission Rate",


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
This simply removes the extra measure abbreviation at the end of PDS-AD and PND-AD. Those extra abbreviations are already called out in the table itself.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6161

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Navigate to a 2026 Adult Core Set
- Find PDS-AD in the measures list. The measure name column should read: "PDS-AD - Postpartum Depression Screening and Follow-Up: Age 21 and Older"
- Note it should not show (PDS-AD) at the end.
- Open the PDS-AD measure
- At the top of the form, the heading should display: "PDS-AD - Postpartum Depression Screening and Follow-Up: Age 21 and Older". Noting that theres no (PDS-AD) suffix.
- Repeat these steps for PND-AD

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary
