### PR TITLE
2026 - Measure Stratification Bugs

### DIFF
--- a/services/ui-src/src/measures/2026/validationTemplate.tsx
+++ b/services/ui-src/src/measures/2026/validationTemplate.tsx
@@ -202,7 +202,7 @@ export const validationTemplate = (
   const OPM = data[DC.OPM_RATES];
 
   const locationDictionary = GV.omsLocationDictionary(
-    OMSData(2026, true),
+    OMSData(2026, true, data.OptionalMeasureStratification?.version, coreSetId),
     qualifiers,
     categories
   );
@@ -489,11 +489,7 @@ export const validationTemplate = (
       dataSource: PMD.override?.omsValidations?.dataSource //used in validateRateZeroOMS
         ? data[DC.DATA_SOURCE]
         : undefined,
-      locationDictionary: GV.omsLocationDictionary(
-        OMSData(2026, true),
-        qualifiers,
-        categories
-      ),
+      locationDictionary,
       validationCallbacks: sortOMSValidations(OPM, PMD)!.flat(),
     })
   );

--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.test.tsx
@@ -253,6 +253,25 @@ describe("Test MeasureStratification", () => {
     expect(screen.queryByText("Foster Care")).not.toBeInTheDocument();
   });
 
+  test("Test 2026 AC (combined-only) shows Medicaid Expansion", async () => {
+    renderMeasureStratification(2026, "AC");
+
+    await userEvent.click(
+      screen.getByRole("radio", {
+        name: "Yes",
+      })
+    );
+
+    await userEvent.click(
+      screen.getByRole("radio", {
+        name: /2024 OMB Statistical Policy Directive No\. 15 race and ethnicity standards/i,
+      })
+    );
+
+    expect(screen.getByText("Medicaid Expansion")).toBeInTheDocument();
+    expect(screen.queryByText("Foster Care")).not.toBeInTheDocument();
+  });
+
   test("Test 2026 ACSM shows Medicaid Expansion with 1997 standards", async () => {
     renderMeasureStratification(2026, "ACSM");
 
@@ -274,6 +293,25 @@ describe("Test MeasureStratification", () => {
 
   test("Test 2026 CCSM shows Foster Care only", async () => {
     renderMeasureStratification(2026, "CCSM");
+
+    await userEvent.click(
+      screen.getByRole("radio", {
+        name: "Yes",
+      })
+    );
+
+    await userEvent.click(
+      screen.getByRole("radio", {
+        name: /2024 OMB Statistical Policy Directive No\. 15 race and ethnicity standards/i,
+      })
+    );
+
+    expect(screen.getByText("Foster Care")).toBeInTheDocument();
+    expect(screen.queryByText("Medicaid Expansion")).not.toBeInTheDocument();
+  });
+
+  test("Test 2026 CC (combined-only) shows Foster Care", async () => {
+    renderMeasureStratification(2026, "CC");
 
     await userEvent.click(
       screen.getByRole("radio", {

--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.test.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.test.tsx
@@ -253,6 +253,25 @@ describe("Test MeasureStratification", () => {
     expect(screen.queryByText("Foster Care")).not.toBeInTheDocument();
   });
 
+  test("Test 2026 ACSM shows Medicaid Expansion with 1997 standards", async () => {
+    renderMeasureStratification(2026, "ACSM");
+
+    await userEvent.click(
+      screen.getByRole("radio", {
+        name: "Yes",
+      })
+    );
+
+    await userEvent.click(
+      screen.getByRole("radio", {
+        name: /1997 OMB minimum race and ethnicity standards/i,
+      })
+    );
+
+    expect(screen.getByText("Medicaid Expansion")).toBeInTheDocument();
+    expect(screen.queryByText("Foster Care")).not.toBeInTheDocument();
+  });
+
   test("Test 2026 CCSM shows Foster Care only", async () => {
     renderMeasureStratification(2026, "CCSM");
 
@@ -272,6 +291,25 @@ describe("Test MeasureStratification", () => {
     expect(screen.queryByText("Medicaid Expansion")).not.toBeInTheDocument();
   });
 
+  test("Test 2026 CCSM shows Foster Care with 1997 standards", async () => {
+    renderMeasureStratification(2026, "CCSM");
+
+    await userEvent.click(
+      screen.getByRole("radio", {
+        name: "Yes",
+      })
+    );
+
+    await userEvent.click(
+      screen.getByRole("radio", {
+        name: /1997 OMB minimum race and ethnicity standards/i,
+      })
+    );
+
+    expect(screen.getByText("Foster Care")).toBeInTheDocument();
+    expect(screen.queryByText("Medicaid Expansion")).not.toBeInTheDocument();
+  });
+
   test("Test 2026 HHCS SPA id shows both Foster Care and Medicaid Expansion", async () => {
     renderMeasureStratification(2026, "HHCS_24-0020");
 
@@ -284,6 +322,25 @@ describe("Test MeasureStratification", () => {
     await userEvent.click(
       screen.getByRole("radio", {
         name: /2024 OMB Statistical Policy Directive No\. 15 race and ethnicity standards/i,
+      })
+    );
+
+    expect(screen.getByText("Foster Care")).toBeInTheDocument();
+    expect(screen.getByText("Medicaid Expansion")).toBeInTheDocument();
+  });
+
+  test("Test 2026 HHCS SPA id shows both Foster Care and Medicaid Expansion with 1997 standards", async () => {
+    renderMeasureStratification(2026, "HHCS_24-0020");
+
+    await userEvent.click(
+      screen.getByRole("radio", {
+        name: "Yes",
+      })
+    );
+
+    await userEvent.click(
+      screen.getByRole("radio", {
+        name: /1997 OMB minimum race and ethnicity standards/i,
       })
     );
 

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
@@ -209,7 +209,7 @@ const omb2024 = (): OmsNode[] => {
 const strat2026 = (coreSetId?: string, baseData = omb2024()): OmsNode[] => {
   const data: OmsNode[] = [...baseData];
 
-  // Foster Care: Child Medicaid + Health Home only
+  // Foster Care: Child Core Set (CCS/CCSM) + Health Home only
   // Includes both separated reports (CCSM) and combined reports (CCS)
   if (
     coreSetId?.startsWith("HHCS") ||
@@ -233,7 +233,7 @@ const strat2026 = (coreSetId?: string, baseData = omb2024()): OmsNode[] => {
     });
   }
 
-  // Medicaid Expansion: Adult Medicaid + Health Home only
+  // Medicaid Expansion: Adult Core Set (ACS/ACSM) + Health Home only
   // Includes both separated reports (ACSM) and combined reports (ACS)
   if (
     coreSetId?.startsWith("HHCS") ||

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
@@ -210,11 +210,12 @@ const strat2026 = (coreSetId?: string, baseData = omb2024()): OmsNode[] => {
   const data: OmsNode[] = [...baseData];
 
   // Foster Care: Child Core Set (CCS/CCSM) + Health Home only
-  // Includes both separated reports (CCSM) and combined reports (CCS)
+  // Includes both separated reports (CCSM) and combined reports (CCS, CC)
   if (
     coreSetId?.startsWith("HHCS") ||
     coreSetId === "CCSM" ||
-    coreSetId === "CCS"
+    coreSetId === "CCS" ||
+    coreSetId === "CC"
   ) {
     data.push({
       id: "ggYk0j",
@@ -234,11 +235,12 @@ const strat2026 = (coreSetId?: string, baseData = omb2024()): OmsNode[] => {
   }
 
   // Medicaid Expansion: Adult Core Set (ACS/ACSM) + Health Home only
-  // Includes both separated reports (ACSM) and combined reports (ACS)
+  // Includes both separated reports (ACSM) and combined reports (ACS, AC)
   if (
     coreSetId?.startsWith("HHCS") ||
     coreSetId === "ACSM" ||
-    coreSetId === "ACS"
+    coreSetId === "ACS" ||
+    coreSetId === "AC"
   ) {
     data.push({
       id: "KSB26p",

--- a/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
+++ b/services/ui-src/src/shared/commonQuestions/OptionalMeasureStrat/data.ts
@@ -33,7 +33,9 @@ export const OMSData = (
         return modifyMissingLabel(removeRaceAndEthnicity(strat2026(coreSetId)));
       }
       return modifyMissingLabel(
-        version === "1997-omb" ? omb1997() : strat2026(coreSetId)
+        version === "1997-omb"
+          ? strat2026(coreSetId, omb1997())
+          : strat2026(coreSetId)
       );
   }
 };
@@ -204,11 +206,16 @@ const omb2024 = (): OmsNode[] => {
   ];
 };
 
-const strat2026 = (coreSetId?: string): OmsNode[] => {
-  const data: OmsNode[] = [...omb2024()];
+const strat2026 = (coreSetId?: string, baseData = omb2024()): OmsNode[] => {
+  const data: OmsNode[] = [...baseData];
 
   // Foster Care: Child Medicaid + Health Home only
-  if (coreSetId?.startsWith("HHCS") || coreSetId === "CCSM") {
+  // Includes both separated reports (CCSM) and combined reports (CCS)
+  if (
+    coreSetId?.startsWith("HHCS") ||
+    coreSetId === "CCSM" ||
+    coreSetId === "CCS"
+  ) {
     data.push({
       id: "ggYk0j",
       label: "Foster Care",
@@ -227,7 +234,12 @@ const strat2026 = (coreSetId?: string): OmsNode[] => {
   }
 
   // Medicaid Expansion: Adult Medicaid + Health Home only
-  if (coreSetId?.startsWith("HHCS") || coreSetId === "ACSM") {
+  // Includes both separated reports (ACSM) and combined reports (ACS)
+  if (
+    coreSetId?.startsWith("HHCS") ||
+    coreSetId === "ACSM" ||
+    coreSetId === "ACS"
+  ) {
     data.push({
       id: "KSB26p",
       label: "Medicaid Expansion",

--- a/services/ui-src/src/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/shared/globalValidations/omsValidator/index.ts
@@ -333,8 +333,8 @@ export const omsValidations = ({
 
   let errorArray: FormError[] = [];
 
-  // Use the caller-provided location dictionary so error locations match
-  // the currently rendered stratification tree (including core-set specific nodes).
+  //use the dictionary passed in
+  //this keeps error labels the same as what users see on screen
   const dictionary = locationDictionary;
 
   const omsRates = getOMSRates(data, dictionary);

--- a/services/ui-src/src/shared/globalValidations/omsValidator/index.ts
+++ b/services/ui-src/src/shared/globalValidations/omsValidator/index.ts
@@ -8,8 +8,6 @@ import { DefaultFormDataLegacy, DefaultFormData } from "shared/types/FormData";
 import { validatePartialRateCompletionOMS } from "shared/globalValidations/validatePartialRateCompletion";
 import { cleanString, hasNumOrDenom, isLegacyLabel, LabelData } from "utils";
 import { featuresByYear } from "utils/featuresByYear";
-import { omsLocationDictionary } from "../dataDrivenTools";
-import { OMSData } from "shared/commonQuestions/OptionalMeasureStrat/data";
 
 interface OmsValidationProps {
   data: DefaultFormData | DefaultFormDataLegacy;
@@ -335,11 +333,9 @@ export const omsValidations = ({
 
   let errorArray: FormError[] = [];
 
-  //if there's a version and it is 1997, we want to use a very specific data set for looks up values, if not, we will use what is passed in
-  const dictionary =
-    data.OptionalMeasureStratification?.version === "1997-omb"
-      ? omsLocationDictionary(OMSData(2024), categories, qualifiers)
-      : locationDictionary;
+  // Use the caller-provided location dictionary so error locations match
+  // the currently rendered stratification tree (including core-set specific nodes).
+  const dictionary = locationDictionary;
 
   const omsRates = getOMSRates(data, dictionary);
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
* New foster care/medicaid accordion only being displayed for 2024 and not applicable is fixed
* New dropdown isn't showing up on one-report states fixed
* Behind-the-scenes rate label being displayed for foster care/medicaid validation fixed

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6225

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://ds4tuyi03hdi6.cloudfront.net/
* Navigate to 2026 child or adult measure
* Fill the form and see either foster care or medicaid is displayed whether it's 2026 or 1997 under stratification section
* Fill the form including foster care or medicaid section (use incorrect measure) and click validate to see error message labels are user friendly labels 

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
