### PR TITLE
[CMDCT-6289] Bugfix: Optional Stratification Not Showing On Cleared Cache

### DIFF
--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.tsx
@@ -216,10 +216,10 @@ export const MeasureStrat = (props: Types.OMSProps) => {
       </QMR.Accordion>
       <StratificationOption reset={onReset} year={year}></StratificationOption>
       {shouldShowDetailsSection && detailsSection}
-      {shouldShowStratification && omsData && (
+      {shouldShowStratification && (
         <Stratification
           {...props}
-          omsData={omsData}
+          omsData={omsData!}
           year={year}
         ></Stratification>
       )}

--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.tsx
@@ -3,7 +3,7 @@ import * as QMR from "components";
 import * as Types from "../../types";
 import { useContext, useMemo } from "react";
 import { useParams } from "react-router-dom";
-import { useFormContext } from "react-hook-form";
+import { useFormContext, useWatch } from "react-hook-form";
 import { OMSData } from "../OptionalMeasureStrat/data";
 import { Stratification } from "./Stratification";
 import SharedContext from "shared/SharedContext";
@@ -106,10 +106,15 @@ export const MeasureStrat = (props: Types.OMSProps) => {
   const { coreset } = props;
   const { coreSetId } = useParams();
 
-  const { watch, getValues, setValue, resetField, formState } =
+  const { getValues, setValue, resetField, formState } =
     useFormContext<Types.OptionalMeasureStratification>();
-  // Re-run this component whenever anything in the form changes.
-  watch();
+  // Re-run this component only when these two radios change.
+  useWatch({
+    name: [
+      `OptionalMeasureStratification.${DC.REPORTING_STRATIFICATION}`,
+      `OptionalMeasureStratification.${DC.VERSION}`,
+    ],
+  });
   const data = getValues();
   // On load the saved answer can be missing from the live form. So use the
   // live value if it's there, otherwise fall back to the saved one.

--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.tsx
@@ -1,9 +1,9 @@
 import * as CUI from "@chakra-ui/react";
 import * as QMR from "components";
 import * as Types from "../../types";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useMemo } from "react";
 import { useParams } from "react-router-dom";
-import { useFormContext, useWatch } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import { OMSData } from "../OptionalMeasureStrat/data";
 import { Stratification } from "./Stratification";
 import SharedContext from "shared/SharedContext";
@@ -106,34 +106,26 @@ export const MeasureStrat = (props: Types.OMSProps) => {
   const { coreset } = props;
   const { coreSetId } = useParams();
 
-  const { watch, setValue, resetField } =
+  const { watch, getValues, setValue, resetField, formState } =
     useFormContext<Types.OptionalMeasureStratification>();
-  const data = watch();
-  const reportingMeasureStratification = useWatch({
-    name: `OptionalMeasureStratification.${DC.REPORTING_STRATIFICATION}`,
-  });
+  // Re-run this component whenever anything in the form changes.
+  watch();
+  const data = getValues();
+  // On load the saved answer can be missing from the live form. So use the
+  // live value if it's there, otherwise fall back to the saved one.
+  const liveOms = data.OptionalMeasureStratification;
+  const defaultOms = formState.defaultValues?.OptionalMeasureStratification;
+  const reportingMeasureStratification =
+    liveOms?.[DC.REPORTING_STRATIFICATION] ??
+    defaultOms?.[DC.REPORTING_STRATIFICATION];
   const shouldUseReportingMeasureStratification =
     featuresByYear.useStratificationYesNo;
 
-  const [version, setVersion] = useState<string>();
-  const [omsData, setOMSData] = useState<Types.OmsNode[]>();
-
-  useEffect(() => {
-    if (
-      data.OptionalMeasureStratification?.version != undefined &&
-      data.OptionalMeasureStratification.version != version
-    ) {
-      setVersion(data.OptionalMeasureStratification.version);
-      setOMSData(
-        OMSData(
-          year,
-          coreset === "adult",
-          data.OptionalMeasureStratification.version,
-          coreSetId
-        )
-      );
-    }
-  }, [data.OptionalMeasureStratification?.version]);
+  const version = liveOms?.[DC.VERSION] ?? defaultOms?.[DC.VERSION];
+  const omsData = useMemo(() => {
+    if (version == undefined) return undefined;
+    return OMSData(year, coreset === "adult", version, coreSetId);
+  }, [version, year, coreset, coreSetId]);
 
   const onReset = () => {
     if (!data.OptionalMeasureStratification?.selections) return;
@@ -224,10 +216,10 @@ export const MeasureStrat = (props: Types.OMSProps) => {
       </QMR.Accordion>
       <StratificationOption reset={onReset} year={year}></StratificationOption>
       {shouldShowDetailsSection && detailsSection}
-      {shouldShowStratification && (
+      {shouldShowStratification && omsData && (
         <Stratification
           {...props}
-          omsData={omsData!}
+          omsData={omsData}
           year={year}
         ></Stratification>
       )}


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
When a user reopens a measure that already has a saved measure stratification selection, the stratification section intermittently fails to display on page load. The option still appears selected, but the details section and the user's previously entered answers are hidden, making it look like their data is gone. This happens after a hard reload, with no user interaction.

Video of the bug fixed!

https://github.com/user-attachments/assets/35627636-7ae1-4a91-ac73-8f160be20942


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
[CMDCT-6289](https://jiraent.cms.gov/browse/CMDCT-6289)

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- Open a measure.
- Fill out the measure and select "Yes" for "Are you reporting measure stratification for this measure?" (or select a race and ethnicity standard), then complete the stratification details.
- Navigate away from the measure page.
- Hard reload the browser.
- Reopen the same measure.
- Observe that the stratification option still shows as selected, but the stratification section is not displayed.

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Product: This work has been reviewed and approved by product owner, if necessary
