### PR TITLE
[CMDCT-6229] Update banners for 2026 with new stratification message

### DIFF
--- a/services/ui-src/src/components/MeasureWrapper/index.test.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.test.tsx
@@ -159,6 +159,34 @@ describe("non-state user", () => {
   });
 });
 
+describe("stratification reminder banner", () => {
+  const renderBanner = (stratificationRequired: string[]) => {
+    useParamsSpy.mockReturnValue({ state: "OH", coreSetId: "ACSM" });
+    renderMeasureWrapper(
+      { measureId: "AMM-AD" },
+      { useGetMeasureValues: { data: { Item: { stratificationRequired } } } }
+    );
+  };
+
+  beforeEach(() => {
+    mockUseUser.mockImplementation(() => ({ isStateUser: true }));
+  });
+
+  it("renders the banner when stratification is required for the core set", () => {
+    renderBanner(["ACSM"]);
+    expect(
+      screen.getByText(/states are expected to report stratified/i)
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the banner when stratification is not required", () => {
+    renderBanner([]);
+    expect(
+      screen.queryByText(/states are expected to report stratified/i)
+    ).not.toBeInTheDocument();
+  });
+});
+
 describe("test auto-completed measures", () => {
   beforeEach(() => {
     mockUseUser.mockImplementation(() => {

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -459,6 +459,23 @@ export const MeasureWrapper = ({
     return `${measureId} - ${cleanTitle} - ${year} QMR`;
   })();
 
+  const baseStratificationText = `For ${year} Core Sets reporting, states are expected to report stratified data for this measure`;
+  const optionalStratificationByCoreSet: Partial<Record<CoreSetAbbr, string>> =
+    {
+      [CoreSetAbbr.CCSM]:
+        " States are encouraged, but not required, to report stratified data for foster care.",
+      [CoreSetAbbr.ACSM]:
+        " States are encouraged, but not required, to report stratified data for Medicaid expansion.",
+      [CoreSetAbbr.HHCS]:
+        " States are encouraged, but not required, to report stratified data for foster care and Medicaid expansion.",
+    };
+  const stratificationBannerDescription =
+    featuresByYear.hasTailoredStratificationBanner
+      ? `${baseStratificationText} for each of the following required stratification standards: race and ethnicity, sex, and geography.${
+          optionalStratificationByCoreSet[coreSet] ?? ""
+        }`
+      : `${baseStratificationText}.`;
+
   return (
     <FormProvider {...methods}>
       <QMR.Title tabTitle={tabTitle} />
@@ -507,9 +524,7 @@ export const MeasureWrapper = ({
                   {stratificationRequired?.includes(coreSet) && (
                     <CUI.Box mb="1rem">
                       <Alert heading="Reminder: Measure Stratification Required">
-                        <CUI.Text>
-                          {`For ${year} Core Sets reporting, states are expected to report stratified data for this measure.`}
-                        </CUI.Text>
+                        <CUI.Text>{stratificationBannerDescription}</CUI.Text>
                       </Alert>
                     </CUI.Box>
                   )}

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -28,7 +28,7 @@ import SharedContext from "shared/SharedContext";
 import * as Labels from "labels/Labels";
 import { coreSetBreadCrumbTitle, coreSetTitles } from "shared/coreSetByYear";
 import { featuresByYear } from "utils/featuresByYear";
-import { getStratificationBannerText } from "./stratificationBanner";
+import { getStratificationBannerDescription } from "./stratificationBanner";
 import { Alert } from "@cmsgov/design-system";
 import { MeasureTemplateData } from "shared/types/MeasureTemplate";
 import { SPA } from "libs/spaLib";
@@ -460,7 +460,7 @@ export const MeasureWrapper = ({
     return `${measureId} - ${cleanTitle} - ${year} QMR`;
   })();
 
-  const stratificationBannerDescription = getStratificationBannerText(
+  const stratificationBannerDescription = getStratificationBannerDescription(
     year,
     coreSet,
     featuresByYear.hasTailoredStratificationBanner

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -28,6 +28,7 @@ import SharedContext from "shared/SharedContext";
 import * as Labels from "labels/Labels";
 import { coreSetBreadCrumbTitle, coreSetTitles } from "shared/coreSetByYear";
 import { featuresByYear } from "utils/featuresByYear";
+import { getStratificationBannerText } from "./stratificationBanner";
 import { Alert } from "@cmsgov/design-system";
 import { MeasureTemplateData } from "shared/types/MeasureTemplate";
 import { SPA } from "libs/spaLib";
@@ -459,22 +460,11 @@ export const MeasureWrapper = ({
     return `${measureId} - ${cleanTitle} - ${year} QMR`;
   })();
 
-  const baseStratificationText = `For ${year} Core Sets reporting, states are expected to report stratified data for this measure`;
-  const optionalStratificationByCoreSet: Partial<Record<CoreSetAbbr, string>> =
-    {
-      [CoreSetAbbr.CCSM]:
-        " States are encouraged, but not required, to report stratified data for foster care.",
-      [CoreSetAbbr.ACSM]:
-        " States are encouraged, but not required, to report stratified data for Medicaid expansion.",
-      [CoreSetAbbr.HHCS]:
-        " States are encouraged, but not required, to report stratified data for foster care and Medicaid expansion.",
-    };
-  const stratificationBannerDescription =
+  const stratificationBannerDescription = getStratificationBannerText(
+    year,
+    coreSet,
     featuresByYear.hasTailoredStratificationBanner
-      ? `${baseStratificationText} for each of the following required stratification standards: race and ethnicity, sex, and geography.${
-          optionalStratificationByCoreSet[coreSet] ?? ""
-        }`
-      : `${baseStratificationText}.`;
+  );
 
   return (
     <FormProvider {...methods}>

--- a/services/ui-src/src/components/MeasureWrapper/stratificationBanner.test.ts
+++ b/services/ui-src/src/components/MeasureWrapper/stratificationBanner.test.ts
@@ -1,0 +1,51 @@
+import { CoreSetAbbr } from "types";
+import { getStratificationBannerText } from "./stratificationBanner";
+
+describe("getStratificationBannerText", () => {
+  describe("generic banner (hasTailoredStratificationBanner = false)", () => {
+    it("returns the single generic sentence with the given year", () => {
+      expect(getStratificationBannerText("2025", CoreSetAbbr.ACSM, false)).toBe(
+        "For 2025 Core Sets reporting, states are expected to report stratified data for this measure."
+      );
+    });
+
+    it("ignores the core set", () => {
+      expect(getStratificationBannerText("2025", CoreSetAbbr.HHCS, false)).toBe(
+        getStratificationBannerText("2025", CoreSetAbbr.ACS, false)
+      );
+    });
+  });
+
+  describe("tailored banner (hasTailoredStratificationBanner = true)", () => {
+    it("names the required stratification standards", () => {
+      const text = getStratificationBannerText("2026", CoreSetAbbr.ACS, true);
+      expect(text).toContain(
+        "For 2026 Core Sets reporting, states are expected to report stratified data for this measure for each of the following required stratification standards: race and ethnicity, sex, and geography."
+      );
+    });
+
+    it("appends no optional sentence for a core set without tailored text", () => {
+      const text = getStratificationBannerText("2026", CoreSetAbbr.ACS, true);
+      expect(text).not.toContain("encouraged, but not required");
+    });
+
+    it.each([
+      [
+        CoreSetAbbr.ACSM,
+        "States are encouraged, but not required, to report stratified data for Medicaid expansion.",
+      ],
+      [
+        CoreSetAbbr.CCSM,
+        "States are encouraged, but not required, to report stratified data for foster care.",
+      ],
+      [
+        CoreSetAbbr.HHCS,
+        "States are encouraged, but not required, to report stratified data for foster care and Medicaid expansion.",
+      ],
+    ])("appends the optional sentence for %s", (coreSet, optionalSentence) => {
+      const text = getStratificationBannerText("2026", coreSet, true);
+      // exactly one space joins the required and optional sentences
+      expect(text).toContain(`geography. ${optionalSentence}`);
+    });
+  });
+});

--- a/services/ui-src/src/components/MeasureWrapper/stratificationBanner.test.ts
+++ b/services/ui-src/src/components/MeasureWrapper/stratificationBanner.test.ts
@@ -1,31 +1,43 @@
 import { CoreSetAbbr } from "types";
-import { getStratificationBannerText } from "./stratificationBanner";
+import { getStratificationBannerDescription } from "./stratificationBanner";
 
-describe("getStratificationBannerText", () => {
+describe("getStratificationBannerDescription", () => {
   describe("generic banner (hasTailoredStratificationBanner = false)", () => {
     it("returns the single generic sentence with the given year", () => {
-      expect(getStratificationBannerText("2025", CoreSetAbbr.ACSM, false)).toBe(
+      expect(
+        getStratificationBannerDescription("2025", CoreSetAbbr.ACSM, false)
+      ).toBe(
         "For 2025 Core Sets reporting, states are expected to report stratified data for this measure."
       );
     });
 
     it("ignores the core set", () => {
-      expect(getStratificationBannerText("2025", CoreSetAbbr.HHCS, false)).toBe(
-        getStratificationBannerText("2025", CoreSetAbbr.ACS, false)
+      expect(
+        getStratificationBannerDescription("2025", CoreSetAbbr.HHCS, false)
+      ).toBe(
+        getStratificationBannerDescription("2025", CoreSetAbbr.ACS, false)
       );
     });
   });
 
   describe("tailored banner (hasTailoredStratificationBanner = true)", () => {
     it("names the required stratification standards", () => {
-      const text = getStratificationBannerText("2026", CoreSetAbbr.ACS, true);
+      const text = getStratificationBannerDescription(
+        "2026",
+        CoreSetAbbr.ACS,
+        true
+      );
       expect(text).toContain(
         "For 2026 Core Sets reporting, states are expected to report stratified data for this measure for each of the following required stratification standards: race and ethnicity, sex, and geography."
       );
     });
 
     it("appends no optional sentence for a core set without tailored text", () => {
-      const text = getStratificationBannerText("2026", CoreSetAbbr.ACS, true);
+      const text = getStratificationBannerDescription(
+        "2026",
+        CoreSetAbbr.ACS,
+        true
+      );
       expect(text).not.toContain("encouraged, but not required");
     });
 
@@ -43,8 +55,7 @@ describe("getStratificationBannerText", () => {
         "States are encouraged, but not required, to report stratified data for foster care and Medicaid expansion.",
       ],
     ])("appends the optional sentence for %s", (coreSet, optionalSentence) => {
-      const text = getStratificationBannerText("2026", coreSet, true);
-      // exactly one space joins the required and optional sentences
+      const text = getStratificationBannerDescription("2026", coreSet, true);
       expect(text).toContain(`geography. ${optionalSentence}`);
     });
   });

--- a/services/ui-src/src/components/MeasureWrapper/stratificationBanner.ts
+++ b/services/ui-src/src/components/MeasureWrapper/stratificationBanner.ts
@@ -9,8 +9,8 @@ const optionalStratificationByCoreSet: Partial<Record<CoreSetAbbr, string>> = {
     "States are encouraged, but not required, to report stratified data for foster care and Medicaid expansion.",
 };
 
-export const getStratificationBannerText = (
-  year: string | number,
+export const getStratificationBannerDescription = (
+  year: string,
   coreSet: CoreSetAbbr,
   hasTailoredStratificationBanner: boolean
 ): string => {

--- a/services/ui-src/src/components/MeasureWrapper/stratificationBanner.ts
+++ b/services/ui-src/src/components/MeasureWrapper/stratificationBanner.ts
@@ -1,0 +1,29 @@
+import { CoreSetAbbr } from "types";
+
+const optionalStratificationByCoreSet: Partial<Record<CoreSetAbbr, string>> = {
+  [CoreSetAbbr.CCSM]:
+    "States are encouraged, but not required, to report stratified data for foster care.",
+  [CoreSetAbbr.ACSM]:
+    "States are encouraged, but not required, to report stratified data for Medicaid expansion.",
+  [CoreSetAbbr.HHCS]:
+    "States are encouraged, but not required, to report stratified data for foster care and Medicaid expansion.",
+};
+
+export const getStratificationBannerText = (
+  year: string | number,
+  coreSet: CoreSetAbbr,
+  hasTailoredStratificationBanner: boolean
+): string => {
+  const base = `For ${year} Core Sets reporting, states are expected to report stratified data for this measure`;
+
+  if (!hasTailoredStratificationBanner) {
+    return `${base}.`;
+  }
+
+  return [
+    `${base} for each of the following required stratification standards: race and ethnicity, sex, and geography.`,
+    optionalStratificationByCoreSet[coreSet],
+  ]
+    .filter(Boolean)
+    .join(" ");
+};

--- a/services/ui-src/src/utils/featuresByYear.ts
+++ b/services/ui-src/src/utils/featuresByYear.ts
@@ -207,4 +207,16 @@ export const featuresByYear = {
   get displayAuditOrValidation() {
     return getMeasureYear() < 2026;
   },
+
+  /**
+   * Prior to 2026, the measure stratification reminder banner displayed a
+   * single generic message for every report.
+   *
+   * In 2026 and beyond, the banner language is tailored per report (core set),
+   * since the required/optional stratifications now differ by report
+   * (e.g. foster care for Child Medicaid, Medicaid expansion for Adult Medicaid).
+   */
+  get hasTailoredStratificationBanner() {
+    return getMeasureYear() >= 2026;
+  },
 };


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
For 2026, the Measure Stratification Required reminder banner now uses report-specific language, because the required/optional stratifications differ by report. Prior
years (2025 and earlier) are unchanged and keep the original generic sentence.

I've hooked this all up under featuresByYear.hasTailoredStratificationBanner

Result:
**Child Medicaid (CCSM/FUA-CH)**
<img width="1280" height="430" alt="Screenshot 2026-06-25 at 4 34 00 PM" src="https://github.com/user-attachments/assets/bcddd035-9b30-45eb-855b-7ecde965376c" />

**2026 Child Separate CHIP (CCSC/FUA-CH)**
<img width="1315" height="364" alt="Screenshot 2026-06-25 at 4 33 33 PM" src="https://github.com/user-attachments/assets/d899ed73-87d6-4942-9c64-82ffe7daa66a" />

**Adult Medicaid (ACSM/FUA-AD)**
<img width="1292" height="352" alt="Screenshot 2026-06-25 at 4 33 15 PM" src="https://github.com/user-attachments/assets/f85e40d9-e8dd-4491-a839-984aa63ce610" />

**Adult Separate CHIP (ACSC/FUA-AD)**
<img width="1282" height="287" alt="Screenshot 2026-06-25 at 4 32 56 PM" src="https://github.com/user-attachments/assets/226b5488-5a52-4db1-be95-593fcbc741fd" />

**Health Home (HHCS_24-0024/FUA-HH)**
<img width="1280" height="314" alt="Screenshot 2026-06-25 at 4 28 31 PM" src="https://github.com/user-attachments/assets/b351f048-adfb-4717-b5e2-dd7044bba416" />

**2025: Child Separate CHIP (CCSC/FUA-CH)**
<img width="1288" height="310" alt="Screenshot 2026-06-25 at 4 35 53 PM" src="https://github.com/user-attachments/assets/1623af38-ddbf-450f-bb85-f3174dc73b95" />


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6229

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

Run the app locally and log in as stateuser4.

For 2026 Reports:
- Adult Medicaid: open FUA-AD and note the banner ends with "…to report stratified data for Medicaid expansion."
- Child Medicaid: open FUA-CH and note the banner ends with "…to report stratified data for foster care."
- Child Separate CHIP: open FUA-CH and note the banner ends at "…sex, and geography." (no optional sentence)
- Adult Separate CHIP: open measure FUA-AD and see theres still no banner!
- Health Home: a state with HH must first add a Health Home core set (the seed doesn't create
one). Click Add Health Home Core Set, then open it and find measure FUA-HH. Note the banner ends with "…for foster care and Medicaid expansion."

For 2025 and Prior Reports:
- Open any 2025 measure that carries the banner and note it still has the original generic sentence "…states are expected to report stratified data for this measure."

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary