### PR TITLE
2026 remove validation

### DIFF
--- a/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.test.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.test.ts
@@ -40,13 +40,10 @@ describe("validateDefinitionOfDenominatorNoExplain", () => {
     expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([]);
   });
 
-  it.each([["explanation is blank", "", "123"]])(
-    "returns an error when %s",
-    (_case, explanation, excludedPopSize) => {
-      setValues(DC.NO, explanation, excludedPopSize);
-      expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([
-        expectedError,
-      ]);
-    }
-  );
+  it("returns an error when explanation is blank", () => {
+    setValues(DC.NO, "", "123");
+    expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([
+      expectedError,
+    ]);
+  });
 });

--- a/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.test.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.test.ts
@@ -30,18 +30,23 @@ describe("validateDefinitionOfDenominatorNoExplain", () => {
     expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([]);
   });
 
-  it("returns no errors when total tech spec is no and both follow-up fields are filled", () => {
+  it("returns no errors when total tech spec is no and explanation is filled", () => {
     setValues(DC.NO, "Population A is excluded due to missing claims", "123");
     expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([]);
   });
 
-  it.each([
-    ["explanation is blank", "", "123"],
-    ["excluded population size is blank", "Population A is excluded", ""],
-  ])("returns an error when %s", (_case, explanation, excludedPopSize) => {
-    setValues(DC.NO, explanation, excludedPopSize);
-    expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([
-      expectedError,
-    ]);
+  it("returns no errors when total tech spec is no and excluded population size is blank", () => {
+    setValues(DC.NO, "Population A is excluded due to missing claims", "");
+    expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([]);
   });
+
+  it.each([["explanation is blank", "", "123"]])(
+    "returns an error when %s",
+    (_case, explanation, excludedPopSize) => {
+      setValues(DC.NO, explanation, excludedPopSize);
+      expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([
+        expectedError,
+      ]);
+    }
+  );
 });

--- a/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.ts
@@ -5,11 +5,7 @@ export const validateDefinitionOfDenominatorNoExplain = (
   data: Types.DefinitionOfPopulation
 ) => {
   if (data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC] !== DC.NO) return [];
-  if (
-    data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_EXPLAIN] &&
-    data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_SIZE]
-  )
-    return [];
+  if (data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_EXPLAIN]) return [];
 
   return [
     {


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
* Remove validation for "Specify the state of..." from when user selects No for "Does the denominator represent your total..." question

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6316

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d3d3gvuj1c8n9v.cloudfront.net/
* Click any form and fill the form and selects No for "Does the denominator represent your total..." question and just fill the top one and see there's no validation

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
