### PR TITLE
rename featuresByYear flag for clarity and remove check from the top stratification banner

### DIFF
--- a/services/ui-src/src/components/MeasureWrapper/index.test.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.test.tsx
@@ -188,11 +188,11 @@ describe("stratification reminder banner", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not render the banner before 2026", () => {
+  it("renders the banner in 2025 when stratification is required for the core set", () => {
     renderBanner(["ACSM"], "2025");
     expect(
-      screen.queryByText(/states are expected to report stratified/i)
-    ).not.toBeInTheDocument();
+      screen.getByText(/states are expected to report stratified/i)
+    ).toBeInTheDocument();
   });
 
   it("does not render the banner when stratification is not required", () => {

--- a/services/ui-src/src/components/MeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/MeasureWrapper/index.tsx
@@ -468,7 +468,6 @@ export const MeasureWrapper = ({
     featuresByYear.hasTailoredStratificationBanner
   );
   const shouldShowStratificationReminderBanner =
-    featuresByYear.showStratificationReminderBanner &&
     stratificationRequired?.includes(coreSet);
 
   return (

--- a/services/ui-src/src/components/PrintableMeasureWrapper/index.test.tsx
+++ b/services/ui-src/src/components/PrintableMeasureWrapper/index.test.tsx
@@ -96,7 +96,7 @@ describe("Test PrintableMeasureWrapper Component", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not render stratification reminder before 2026", () => {
+  it("renders stratification reminder in 2025", () => {
     mockGetMeasureYear.mockReturnValue(2025);
     mockUseParam.mockReturnValue({ coreSetId: "CCSM", state: "MA" });
     renderWithHookForm(
@@ -114,7 +114,7 @@ describe("Test PrintableMeasureWrapper Component", () => {
     );
 
     expect(
-      screen.queryByText("Reminder: Measure Stratification Required")
-    ).not.toBeInTheDocument();
+      screen.getByText("Reminder: Measure Stratification Required")
+    ).toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/components/PrintableMeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/PrintableMeasureWrapper/index.tsx
@@ -20,7 +20,6 @@ import { measureDescriptions } from "measures/measureDescriptions";
 import SharedContext from "shared/SharedContext";
 import * as Labels from "labels/Labels";
 import { Alert } from "@cmsgov/design-system";
-import { featuresByYear } from "utils/featuresByYear";
 
 const LastModifiedBy = ({ user }: { user: string | undefined }) => {
   if (!user) return null;
@@ -156,7 +155,6 @@ export const PrintableMeasureWrapper = ({
     measureDescriptions[measureData?.year]?.[measureData?.measure] ||
     measureData?.description;
   const shouldShowStratificationReminderBanner =
-    featuresByYear.showStratificationReminderBanner &&
     measureData?.stratificationRequired?.includes(coreSet);
 
   return (

--- a/services/ui-src/src/components/PrintableMeasureWrapper/index.tsx
+++ b/services/ui-src/src/components/PrintableMeasureWrapper/index.tsx
@@ -34,6 +34,7 @@ export interface PrintableMeasureWrapperProps {
   name: string;
   year: string;
   measureId: string;
+  stratificationRequired?: CoreSetAbbr[];
   setValidationFunctions?: React.Dispatch<React.SetStateAction<any>>;
   isOtherMeasureSpecSelected?: boolean;
   isPrimaryMeasureSpecSelected?: boolean;
@@ -46,6 +47,7 @@ interface MeasureProps {
   name: string;
   year: string;
   measureId: string;
+  stratificationRequired?: CoreSetAbbr[];
   setValidationFunctions: Dispatch<SetStateAction<Function[]>>;
   handleSave: (data: any) => void;
 }
@@ -208,6 +210,7 @@ export const PrintableMeasureWrapper = ({
                     name={foundMeasureDescription || name}
                     year={year}
                     measureId={measureId}
+                    stratificationRequired={measureData?.stratificationRequired}
                     setValidationFunctions={() => {}}
                     handleSave={() => {}}
                   />

--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.tsx
@@ -224,13 +224,13 @@ export const MeasureStrat = (props: Types.OMSProps) => {
     (version === "1997-omb" ||
       version === "2024-omb" ||
       (shouldUseReportingMeasureStratification && version === "not-reporting"));
-  const shouldShowStratificationReminderBanner =
+  const shouldShowStratificationSectionBanner =
     featuresByYear.showStratificationSectionBanner &&
     stratificationRequired?.includes(coreSet);
 
   return (
     <QMR.CoreQuestionWrapper testid="OMS" label="Measure Stratification">
-      {shouldShowStratificationReminderBanner && (
+      {shouldShowStratificationSectionBanner && (
         <CUI.Box mt="24px" mb="32px">
           <Alert
             heading="Reminder: Measure Stratification Required"

--- a/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.tsx
+++ b/services/ui-src/src/shared/commonQuestions/MeasureStratification/index.tsx
@@ -225,7 +225,7 @@ export const MeasureStrat = (props: Types.OMSProps) => {
       version === "2024-omb" ||
       (shouldUseReportingMeasureStratification && version === "not-reporting"));
   const shouldShowStratificationReminderBanner =
-    featuresByYear.showStratificationReminderBanner &&
+    featuresByYear.showStratificationSectionBanner &&
     stratificationRequired?.includes(coreSet);
 
   return (

--- a/services/ui-src/src/utils/featuresByYear.test.ts
+++ b/services/ui-src/src/utils/featuresByYear.test.ts
@@ -11,14 +11,14 @@ describe("featuresByYear stratification banner flags", () => {
   it("disables both flags before 2026", () => {
     mockGetMeasureYear.mockReturnValue(2025);
 
-    expect(featuresByYear.showStratificationReminderBanner).toBe(false);
+    expect(featuresByYear.showStratificationSectionBanner).toBe(false);
     expect(featuresByYear.hasTailoredStratificationBanner).toBe(false);
   });
 
   it("enables both flags in 2026 and later", () => {
     mockGetMeasureYear.mockReturnValue(2026);
 
-    expect(featuresByYear.showStratificationReminderBanner).toBe(true);
+    expect(featuresByYear.showStratificationSectionBanner).toBe(true);
     expect(featuresByYear.hasTailoredStratificationBanner).toBe(true);
   });
 });

--- a/services/ui-src/src/utils/featuresByYear.ts
+++ b/services/ui-src/src/utils/featuresByYear.ts
@@ -209,12 +209,10 @@ export const featuresByYear = {
   },
 
   /**
-   * Prior to 2026, the measure stratification reminder banner was hidden.
-   *
-   * In 2026 and beyond, the reminder banner is displayed for reports where
-   * measure stratification is required.
+   * In 2026, a second reminder banner was added directly above the
+   * Measure Stratification section, in addition to the top-of-page banner.
    */
-  get showStratificationReminderBanner() {
+  get showStratificationSectionBanner() {
     return getMeasureYear() >= 2026;
   },
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->

This pull request updates the logic for displaying the measure stratification reminder banners, clarifying the distinction between the top-of-page banner and the section-specific banner, and ensures the correct banner is shown for 2025 and 2026. The main changes include renaming feature flags, updating logic for when banners are displayed, and adjusting related tests.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6303

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

URL: https://doo1d98sbjund.cloudfront.net/

1. Verify that measure stratification banner appears at the top of the page for 2026 reports
2. Verify that measure stratification second banner appears in the stratification section
3. Verify that measure stratification banner appears at the top of the page for 2025 reports
4. Verify that measure stratification second banner does not appear in the stratification section


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
