### PR TITLE
"Does this denominator" Validation

### DIFF
--- a/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.test.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.test.ts
@@ -30,6 +30,16 @@ describe("validateDefinitionOfDenominatorNoExplain", () => {
     expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([]);
   });
 
+  it("returns required-field error when total tech spec question is skipped", () => {
+    setValues("", "", "");
+    expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([
+      {
+        errorLocation: "Denominator Includes Total Measure-Eligible Population",
+        errorMessage: "You must complete this field",
+      },
+    ]);
+  });
+
   it("returns no errors when total tech spec is no and explanation is filled", () => {
     setValues(DC.NO, "Population A is excluded due to missing claims", "123");
     expect(validateDefinitionOfDenominatorNoExplain(formData)).toEqual([]);

--- a/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.ts
+++ b/services/ui-src/src/shared/globalValidations/validateDefinitionOfDenominatorNoExplain/index.ts
@@ -4,6 +4,15 @@ import * as Types from "shared/types";
 export const validateDefinitionOfDenominatorNoExplain = (
   data: Types.DefinitionOfPopulation
 ) => {
+  if (!data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC]) {
+    return [
+      {
+        errorLocation: "Denominator Includes Total Measure-Eligible Population",
+        errorMessage: "You must complete this field",
+      },
+    ];
+  }
+
   if (data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC] !== DC.NO) return [];
   if (data[DC.DENOMINATOR_DEFINE_TOTAL_TECH_SPEC_NO_EXPLAIN]) return [];
 


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
* Does this denominator validation added when state skips this question

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6378

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d36eqg9j8bqfhy.cloudfront.net/
* Navigate to any form
* Skip "Does this denominator..." question
* Validate and see there's a validation

<img width="1032" height="228" alt="Screenshot 2026-07-31 at 11 32 08 AM" src="https://github.com/user-attachments/assets/a0ca4872-c63e-4b61-a8bf-6b86cc015a8e" />

<img width="1330" height="384" alt="Screenshot 2026-07-31 at 11 31 48 AM" src="https://github.com/user-attachments/assets/e735428f-6566-4f0e-b730-c7237c9891cf" />


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
