### PR TITLE
[CMDCT-6421] Replace DocRaptor with in-Lambda Prince PDF generation

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -12,8 +12,6 @@ S3_ATTACHMENTS_BUCKET_NAME=op://mdct_devs/qmr_secrets/S3_ATTACHMENTS_BUCKET_NAME
 # LAUNCHDARKLY
 REACT_APP_LD_SDK_CLIENT=op://mdct_devs/qmr_secrets/REACT_APP_LD_SDK_CLIENT
 
-docraptorApiKey=op://mdct_devs/qmr_secrets/docraptorApiKey # pragma: allowlist secret
-
 CYPRESS_STATE_USER_2=op://mdct_devs/qmr_secrets/CYPRESS_STATE_USER_2
 CYPRESS_STATE_USER_4=op://mdct_devs/qmr_secrets/CYPRESS_STATE_USER_4
 CYPRESS_ADMIN_USER=op://mdct_devs/qmr_secrets/CYPRESS_ADMIN_USER

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+# Vendored YesLogic Prince packages (fetched by scripts/fetch-prince-*.sh).
+# oxlint respects .eslintignore by default.
+services/app-api/bin/prince/**
+services/app-api/bin/prince-arm64/**

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ cdk.context.json
 **/.yarn/*
 services/ui-src/public/env-config.ts
 .vscode/settings.json
+services/app-api/bin/.generated/
+services/app-api/bin/prince/
+services/app-api/bin/prince-arm64/

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ To run the project, run the following commands from the root of the directory:
 >
 > `./run local` writes UI runtime config to `services/ui-src/public/env-config.js` based on CloudFormation outputs and then starts the Vite dev server.
 
+LocalStack PDF export needs the YesLogic **Linux** AWS Lambda Prince package (gitignored under `services/app-api/bin/prince/`). CDK synth downloads it automatically on first local deploy (SHA-256 pinned in `deployment/utils/prince-asset.ts`); refresh manually with `./scripts/fetch-prince-linux.sh`.
+
+Cloud accounts (once per account): `./run deploy-prerequisites` to create the Prince assets bucket, then `PROJECT=qmr ./scripts/publish-prince-asset.sh` to upload the pinned zip. Optional paid license: add a `princeLicense` string (license.dat XML) to the `qmr-default` Secrets Manager secret; otherwise the demo license is used.
+
 To login, a number of test users are provisioned via `services/ui-auth/libs/users.json`. Check 1Password in the `qmr_secrets` section for the test user password.
 
 #### oxfmt and oxlint

--- a/deployment/deployment-config.ts
+++ b/deployment/deployment-config.ts
@@ -1,4 +1,5 @@
 import { isLocalStack } from "./local/util.ts";
+import { resolvePrincePackageDir } from "./utils/prince-asset.ts";
 import { getSecret } from "./utils/secrets-manager.ts";
 
 export interface DeploymentConfigProperties {
@@ -13,7 +14,6 @@ export interface DeploymentConfigProperties {
   oktaMetadataUrl: string;
   launchDarklyClient: string;
   redirectSignout: string;
-  docraptorApiKey: string;
   bootstrapUsersPassword?: string;
   vpnIpSetArn?: string;
   vpnIpv6SetArn?: string;
@@ -24,6 +24,8 @@ export interface DeploymentConfigProperties {
   userPoolDomainPrefix?: string;
   kafkaClientId?: string;
   bucketPrefix?: string;
+  princeLicense?: string;
+  princePackageDir?: string;
 }
 
 export const determineDeploymentConfig = async (stage: string) => {
@@ -39,6 +41,10 @@ export const determineDeploymentConfig = async (stage: string) => {
     stage,
     isDev,
     ...secretConfigOptions,
+    princePackageDir:
+      stage === "bootstrap"
+        ? undefined
+        : await resolvePrincePackageDir(project),
   };
   if (config.cloudfrontDomainName) {
     config.secureCloudfrontDomainName = `https://${config.cloudfrontDomainName}/`;
@@ -85,7 +91,6 @@ function validateConfig(config: {
     "oktaMetadataUrl",
     "launchDarklyClient",
     "redirectSignout",
-    "docraptorApiKey",
   ];
 
   const invalidKeys = expectedKeys.filter(

--- a/deployment/local/README.md
+++ b/deployment/local/README.md
@@ -68,3 +68,20 @@ awslocal --version
 # example of something you'd pop in as YOUR_FUNCTION_NAME => app-api-localstack-getUserById
 awslocal lambda get-function-configuration --function-name YOUR_FUNCTION_NAME --query "Environment.Variables"
 ```
+
+### Prince PDF
+
+Local PDF export on Ministack with Apple Silicon uses the macOS Prince tree at `services/app-api/bin/prince-arm64/` (not the Linux AWS package under `bin/prince/`). Refresh with:
+
+```sh
+./scripts/fetch-prince-macos.sh
+```
+
+Real AWS deploys use the YesLogic AWS Lambda package under `services/app-api/bin/prince/`:
+
+```sh
+./scripts/fetch-prince-linux.sh
+# optional: PRINCE_VERSION=16.2 ./scripts/fetch-prince-linux.sh
+```
+
+Vendor binaries are large; run the fetch scripts after cloning if `bin/prince*` is missing.

--- a/deployment/local/prerequisites.ts
+++ b/deployment/local/prerequisites.ts
@@ -42,9 +42,6 @@ export class LocalPrerequisiteStack extends Stack {
         oktaMetadataUrl: SecretValue.unsafePlainText("localstack"),
         launchDarklyClient: SecretValue.unsafePlainText("localstack"),
         redirectSignout: SecretValue.unsafePlainText("localstack"),
-        docraptorApiKey: SecretValue.unsafePlainText(
-          process.env.docraptorApiKey!
-        ),
       },
     });
 

--- a/deployment/prerequisites-additional.ts
+++ b/deployment/prerequisites-additional.ts
@@ -1,0 +1,38 @@
+import {
+  aws_ec2 as ec2,
+  aws_s3 as s3,
+  CfnOutput,
+  RemovalPolicy,
+  Stack,
+} from "aws-cdk-lib";
+import {
+  loadPrinceAssetMeta,
+  princeAssetBucketName,
+} from "./utils/prince-asset.ts";
+
+/**
+ * App-specific cloud prerequisites (imported by deployment/prerequisites.ts).
+ * Creates the private bucket that holds the pinned Prince AWS Lambda zip.
+ */
+export function addAdditionalPrerequisites(stack: Stack, _vpc: ec2.IVpc) {
+  const project = process.env.PROJECT!;
+  const account = stack.account;
+  const meta = loadPrinceAssetMeta();
+  const bucketName = princeAssetBucketName(project, account);
+
+  const princeAssetsBucket = new s3.Bucket(stack, "PrinceAssetsBucket", {
+    bucketName,
+    encryption: s3.BucketEncryption.S3_MANAGED,
+    blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+    enforceSSL: true,
+    versioned: true,
+    // Account-level asset store — keep across stack updates; destroy only if empty.
+    removalPolicy: RemovalPolicy.RETAIN,
+    autoDeleteObjects: false,
+  });
+
+  new CfnOutput(stack, "PrinceAssetsBucketName", {
+    value: princeAssetsBucket.bucketName,
+    description: `Upload prince-${meta.version}-aws-lambda.zip via ./scripts/publish-prince-asset.sh`,
+  });
+}

--- a/deployment/prerequisites.ts
+++ b/deployment/prerequisites.ts
@@ -15,7 +15,7 @@ import { Construct } from "constructs";
 import { CloudWatchLogsResourcePolicy } from "./constructs/cloudwatch-logs-resource-policy.ts";
 import { loadDefaultSecret } from "./deployment-config.ts";
 import { isLocalStack } from "./local/util.ts";
-import { tryImport } from "./utils/misc.ts";
+import { addAdditionalPrerequisites } from "./prerequisites-additional.ts";
 
 interface PrerequisiteConfigProps {
   project: string;
@@ -55,9 +55,8 @@ export class PrerequisiteStack extends Stack {
       vpc.addGatewayEndpoint("S3Endpoint", {
         service: ec2.GatewayVpcEndpointAwsService.S3,
       });
-
-      // add optional app-specific prerequisites
-      this.addAdditionalPrerequisitesAsync(vpc);
+      // App-specific prerequisites (Prince assets bucket).
+      addAdditionalPrerequisites(this, vpc);
     }
 
     new CloudWatchLogsResourcePolicy(this, "logPolicy", { project });
@@ -119,15 +118,6 @@ export class PrerequisiteStack extends Stack {
         iam.ManagedPolicy.fromAwsManagedPolicyName("AdministratorAccess"),
       ],
     });
-  }
-
-  async addAdditionalPrerequisitesAsync(vpc: ec2.IVpc) {
-    const module = await tryImport<{
-      addAdditionalPrerequisites: (stack: Stack, vpc: ec2.IVpc) => void;
-    }>("../prerequisites-additional");
-    if (module?.addAdditionalPrerequisites) {
-      module.addAdditionalPrerequisites(this, vpc);
-    }
   }
 }
 

--- a/deployment/stacks/api.ts
+++ b/deployment/stacks/api.ts
@@ -3,18 +3,29 @@ import {
   aws_apigateway as apigateway,
   aws_ec2 as ec2,
   aws_iam as iam,
+  aws_lambda as lambda,
   aws_logs as logs,
   aws_wafv2 as wafv2,
   CfnOutput,
   Duration,
   RemovalPolicy,
 } from "aws-cdk-lib";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { Lambda } from "../constructs/lambda.ts";
 import { WafConstruct } from "../constructs/waf.ts";
 import { LambdaDynamoEventSource } from "../constructs/lambda-dynamo-event.ts";
 import { DynamoDBTable } from "../constructs/dynamodb-table.ts";
 import { isDefined } from "../utils/misc.ts";
 import { isLocalStack } from "../local/util.ts";
+import { PRINCE_LOCAL_DIR_REL } from "../utils/prince-asset.ts";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const PRINCE_GENERATED_LICENSE_PATH = join(
+  REPO_ROOT,
+  "services/app-api/bin/.generated/prince-license.dat"
+);
 
 interface CreateApiComponentsProps {
   scope: Construct;
@@ -25,8 +36,28 @@ interface CreateApiComponentsProps {
   kafkaAuthorizedSubnets: ec2.ISubnet[];
   tables: DynamoDBTable[];
   brokerString: string;
-  docraptorApiKey: string;
   kafkaClientId?: string;
+  /** Raw Prince license.dat XML; demo license used if absent. */
+  princeLicense?: string;
+  princePackageDir?: string;
+}
+
+/**
+ * Write the effective Prince license into a gitignored path so afterBundling we
+ * can write it into the Lambda zip without putting secret content in shell args.
+ */
+function writePrinceLicenseForBundling(
+  princePackageDir: string,
+  princeLicense?: string
+) {
+  const demoLicensePath = join(
+    REPO_ROOT,
+    princePackageDir,
+    "prince-engine/license/license.dat"
+  );
+  const licenseContent = princeLicense ?? readFileSync(demoLicensePath, "utf8");
+  mkdirSync(dirname(PRINCE_GENERATED_LICENSE_PATH), { recursive: true });
+  writeFileSync(PRINCE_GENERATED_LICENSE_PATH, licenseContent, "utf8");
 }
 
 export function createApiComponents(props: CreateApiComponentsProps) {
@@ -39,8 +70,9 @@ export function createApiComponents(props: CreateApiComponentsProps) {
     kafkaAuthorizedSubnets,
     tables,
     brokerString,
-    docraptorApiKey,
     kafkaClientId,
+    princeLicense,
+    princePackageDir = isLocalStack ? PRINCE_LOCAL_DIR_REL : undefined,
   } = props;
 
   const service = "app-api";
@@ -97,7 +129,6 @@ export function createApiComponents(props: CreateApiComponentsProps) {
   });
 
   const environment = {
-    docraptorApiKey,
     brokerString,
     STAGE: stage,
     KAFKA_CLIENT_ID: kafkaClientId ?? `qmr-${stage}`,
@@ -273,6 +304,27 @@ export function createApiComponents(props: CreateApiComponentsProps) {
     ...commonProps,
   });
 
+  if (!princePackageDir) {
+    throw new Error(
+      "princePackageDir missing from deployment config. " +
+        (isLocalStack
+          ? "Run ./scripts/fetch-prince-linux.sh (local prerequisites)."
+          : "Publish with ./scripts/publish-prince-asset.sh and redeploy.")
+    );
+  }
+
+  const princeWrapperPath = join(REPO_ROOT, princePackageDir, "prince");
+  if (!existsSync(princeWrapperPath)) {
+    throw new Error(
+      `Missing Linux Prince at ${princeWrapperPath}. ` +
+        (isLocalStack
+          ? "Run: ./scripts/fetch-prince-linux.sh"
+          : "Publish with ./scripts/publish-prince-asset.sh and redeploy.")
+    );
+  }
+
+  writePrinceLicenseForBundling(princePackageDir, princeLicense);
+
   new Lambda(scope, "getPDF", {
     entry: "services/app-api/handlers/prince/pdf.ts",
     handler: "getPDF",
@@ -280,6 +332,19 @@ export function createApiComponents(props: CreateApiComponentsProps) {
     method: "POST",
     ...commonProps,
     timeout: Duration.seconds(30), // apigateway's max
+    memorySize: 2048,
+    architecture: lambda.Architecture.X86_64,
+    bundling: {
+      commandHooks: {
+        beforeBundling: () => [],
+        beforeInstall: () => [],
+        afterBundling: (inputDir, outputDir) => [
+          `cp -R ${inputDir}/${princePackageDir}/. ${outputDir}/`,
+          `cp ${inputDir}/services/app-api/bin/.generated/prince-license.dat ${outputDir}/prince-engine/license/license.dat`,
+          `chmod +x ${outputDir}/prince ${outputDir}/prince-engine/bin/prince*`,
+        ],
+      },
+    },
   });
 
   // Data Processor Lambda

--- a/deployment/utils/prince-asset.ts
+++ b/deployment/utils/prince-asset.ts
@@ -122,7 +122,9 @@ async function ensurePrinceFromS3(
 
   const bucket = princeAssetBucketName(project, account);
   const key = princeAssetObjectKey(meta.version);
-  console.log(`Fetching Prince AWS Lambda zip from s3://${bucket}/${key}`);
+  console.log(
+    "Fetching Prince AWS Lambda zip from configured S3 asset location"
+  );
 
   const client = new S3Client({ region: "us-east-1" });
   let response: GetObjectCommandOutput;

--- a/deployment/utils/prince-asset.ts
+++ b/deployment/utils/prince-asset.ts
@@ -1,0 +1,206 @@
+import { createHash } from "node:crypto";
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import {
+  GetObjectCommand,
+  S3Client,
+  type GetObjectCommandOutput,
+} from "@aws-sdk/client-s3";
+import { isLocalStack } from "../local/util.ts";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+export interface PrinceAssetMeta {
+  version: string;
+  sha256: string;
+  url: string;
+}
+
+/** Pinned YesLogic Prince AWS Lambda package (update when bumping Prince). */
+export const PRINCE_ASSET_META: PrinceAssetMeta = {
+  version: "16.2",
+  // Public download checksum — not a credential.
+  sha256: "b936f8cf8cfb4d33b9a1630d94d0091d23cf23bfbefc347d8a7e08ebe62d79c7", // pragma: allowlist secret
+  url: "https://www.princexml.com/download/prince-16.2-aws-lambda.zip",
+};
+
+export const PRINCE_LOCAL_DIR_REL = "services/app-api/bin/prince";
+export const PRINCE_GENERATED_DIR_REL =
+  "services/app-api/bin/.generated/prince";
+
+export function loadPrinceAssetMeta(): PrinceAssetMeta {
+  return PRINCE_ASSET_META;
+}
+
+export function princeAssetBucketName(
+  project: string,
+  account: string
+): string {
+  return `${project}-prince-assets-${account}`;
+}
+
+export function princeAssetObjectKey(
+  version: string = loadPrinceAssetMeta().version
+): string {
+  return `prince/${version}/prince-${version}-aws-lambda.zip`;
+}
+
+/**
+ * LocalStack: gitignored bin/prince (auto-fetches via fetch-prince-linux.sh if missing).
+ * Cloud: S3 object verified against pinned SHA-256, extracted under .generated/.
+ */
+export async function resolvePrincePackageDir(
+  project: string
+): Promise<string> {
+  if (isLocalStack) {
+    return ensurePrinceLocal();
+  }
+
+  const account = process.env.CDK_DEFAULT_ACCOUNT;
+  if (!account) {
+    throw new Error(
+      "CDK_DEFAULT_ACCOUNT is required to resolve the Prince assets bucket"
+    );
+  }
+
+  return ensurePrinceFromS3(project, account);
+}
+
+/**
+ * Ensure the Linux AWS Lambda Prince package exists under bin/prince for LocalStack.
+ * Runs the fetch script on demand so shared cli/commands/local.ts stays untouched.
+ */
+function ensurePrinceLocal(): string {
+  const localDir = join(REPO_ROOT, PRINCE_LOCAL_DIR_REL);
+  const wrapper = join(localDir, "prince");
+  if (!existsSync(wrapper)) {
+    const fetchScript = join(REPO_ROOT, "scripts/fetch-prince-linux.sh");
+    console.log(`Prince package missing at ${wrapper}; running ${fetchScript}`);
+    execFileSync(fetchScript, {
+      cwd: REPO_ROOT,
+      stdio: "inherit",
+    });
+  }
+  if (!existsSync(wrapper)) {
+    throw new Error(
+      `Missing Linux Prince at ${wrapper} after running scripts/fetch-prince-linux.sh`
+    );
+  }
+  return PRINCE_LOCAL_DIR_REL;
+}
+
+async function ensurePrinceFromS3(
+  project: string,
+  account: string
+): Promise<string> {
+  const meta = loadPrinceAssetMeta();
+  const destAbs = join(REPO_ROOT, PRINCE_GENERATED_DIR_REL);
+  const markerPath = join(
+    REPO_ROOT,
+    "services/app-api/bin/.generated/prince.sha256"
+  );
+  const wrapperPath = join(destAbs, "prince");
+
+  if (
+    existsSync(wrapperPath) &&
+    existsSync(markerPath) &&
+    readFileSync(markerPath, "utf8").trim() === meta.sha256
+  ) {
+    return PRINCE_GENERATED_DIR_REL;
+  }
+
+  const bucket = princeAssetBucketName(project, account);
+  const key = princeAssetObjectKey(meta.version);
+  console.log(`Fetching Prince AWS Lambda zip from s3://${bucket}/${key}`);
+
+  const client = new S3Client({ region: "us-east-1" });
+  let response: GetObjectCommandOutput;
+  try {
+    response = await client.send(
+      new GetObjectCommand({ Bucket: bucket, Key: key })
+    );
+  } catch (error: any) {
+    throw new Error(
+      `Failed to download Prince package from s3://${bucket}/${key}. ` +
+        `Publish it once with ./scripts/publish-prince-asset.sh (${error.message})`
+    );
+  }
+
+  if (!response.Body) {
+    throw new Error(`Empty body for s3://${bucket}/${key}`);
+  }
+
+  const tmpDir = join(REPO_ROOT, "services/app-api/bin/.generated");
+  mkdirSync(tmpDir, { recursive: true });
+  const zipPath = join(tmpDir, `prince-${meta.version}-aws-lambda.zip`);
+
+  await pipeline(
+    response.Body as NodeJS.ReadableStream,
+    createWriteStream(zipPath)
+  );
+
+  const zipBytes = readFileSync(zipPath);
+  const digest = createHash("sha256").update(zipBytes).digest("hex");
+  if (digest !== meta.sha256) {
+    rmSync(zipPath, { force: true });
+    throw new Error(
+      `Prince zip SHA-256 mismatch for s3://${bucket}/${key}: expected ${meta.sha256}, got ${digest}`
+    );
+  }
+
+  const unpackDir = join(tmpDir, `prince-unpack-${meta.version}`);
+  rmSync(unpackDir, { recursive: true, force: true });
+  mkdirSync(unpackDir, { recursive: true });
+  execFileSync("unzip", ["-q", zipPath, "-d", unpackDir], { stdio: "inherit" });
+
+  let srcDir = unpackDir;
+  if (!existsSync(join(srcDir, "prince"))) {
+    const entries = readdirSync(srcDir).filter((name) => !name.startsWith("."));
+    if (
+      entries.length === 1 &&
+      existsSync(join(srcDir, entries[0], "prince"))
+    ) {
+      srcDir = join(srcDir, entries[0]);
+    }
+  }
+
+  if (!existsSync(join(srcDir, "prince"))) {
+    throw new Error(
+      `Prince zip from s3://${bucket}/${key} missing ./prince after extract`
+    );
+  }
+
+  rmSync(destAbs, { recursive: true, force: true });
+  mkdirSync(destAbs, { recursive: true });
+  execFileSync("bash", ["-lc", `cp -R "${srcDir}/." "${destAbs}/"`], {
+    stdio: "inherit",
+  });
+
+  execFileSync("find", [destAbs, "-name", "*.cdx.json", "-delete"]);
+  execFileSync("chmod", ["+x", join(destAbs, "prince")]);
+  try {
+    execFileSync("bash", [
+      "-lc",
+      `chmod +x "${destAbs}/prince-engine/bin"/prince*`,
+    ]);
+  } catch {
+    // older layouts
+  }
+
+  writeFileSync(markerPath, `${meta.sha256}\n`, "utf8");
+  rmSync(zipPath, { force: true });
+  rmSync(unpackDir, { recursive: true, force: true });
+
+  return PRINCE_GENERATED_DIR_REL;
+}

--- a/scripts/fetch-prince-linux.sh
+++ b/scripts/fetch-prince-linux.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Fetch the official YesLogic Prince AWS Lambda package into
+# services/app-api/bin/prince/ (gitignored) for LocalStack getPDF bundling.
+# Verifies SHA-256 against deployment/utils/prince-asset.ts.
+#
+# Does not touch bin/prince-arm64/ (see fetch-prince-macos.sh).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST_DIR="${REPO_ROOT}/services/app-api/bin/prince"
+
+read_meta() {
+  (cd "${REPO_ROOT}" && node --import tsx -e "
+    import { loadPrinceAssetMeta } from './deployment/utils/prince-asset.ts';
+    const m = loadPrinceAssetMeta();
+    console.log(m[process.argv[1]]);
+  " "$1")
+}
+
+PRINCE_VERSION="$(read_meta version)"
+EXPECTED_SHA256="$(read_meta sha256)"
+DOWNLOAD_URL="${PRINCE_DOWNLOAD_URL:-$(read_meta url)}"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/prince-linux-XXXXXX")"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+ZIP_PATH="${TMP_DIR}/prince-aws-lambda.zip"
+echo "++ Downloading ${DOWNLOAD_URL}"
+curl -fsSL -o "${ZIP_PATH}" "${DOWNLOAD_URL}"
+
+ACTUAL_SHA256="$(shasum -a 256 "${ZIP_PATH}" | awk '{ print $1 }')"
+if [[ "${ACTUAL_SHA256}" != "${EXPECTED_SHA256}" ]]; then
+  echo "error: Prince zip SHA-256 mismatch" >&2
+  echo "  expected: ${EXPECTED_SHA256}" >&2
+  echo "  actual:   ${ACTUAL_SHA256}" >&2
+  exit 1
+fi
+echo "-- SHA-256 OK (${ACTUAL_SHA256})"
+
+echo "++ Unpacking"
+unzip -q "${ZIP_PATH}" -d "${TMP_DIR}/unpacked"
+
+# Zip contents are at the archive root (prince, prince-engine/, lib/, …).
+SRC_DIR="${TMP_DIR}/unpacked"
+if [[ ! -f "${SRC_DIR}/prince" ]]; then
+  # Tolerate a single top-level directory wrapper if YesLogic changes layout.
+  candidates=("${SRC_DIR}"/*)
+  if [[ ${#candidates[@]} -eq 1 && -d "${candidates[0]}" && -f "${candidates[0]}/prince" ]]; then
+    SRC_DIR="${candidates[0]}"
+  fi
+fi
+
+if [[ ! -f "${SRC_DIR}/prince" ]]; then
+  echo "error: expected ./prince wrapper missing after unpack" >&2
+  ls -la "${TMP_DIR}/unpacked" >&2 || true
+  exit 1
+fi
+
+# Prince 16+ uses prince-engine/bin/prince.${arch}; older packages used bin/prince.
+if [[ ! -d "${SRC_DIR}/prince-engine/bin" ]]; then
+  echo "error: expected prince-engine/bin missing after unpack" >&2
+  exit 1
+fi
+if ! compgen -G "${SRC_DIR}/prince-engine/bin/prince*" >/dev/null; then
+  echo "error: expected prince-engine/bin/prince* binary missing after unpack" >&2
+  ls -la "${SRC_DIR}/prince-engine/bin" >&2 || true
+  exit 1
+fi
+
+if [[ ! -f "${SRC_DIR}/prince-engine/license/license.dat" ]]; then
+  echo "error: expected demo license missing at prince-engine/license/license.dat" >&2
+  exit 1
+fi
+
+echo "++ Staging into ${DEST_DIR}"
+rm -rf "${DEST_DIR}"
+mkdir -p "${DEST_DIR}"
+cp -R "${SRC_DIR}/." "${DEST_DIR}/"
+chmod +x "${DEST_DIR}/prince"
+chmod +x "${DEST_DIR}/prince-engine/bin"/prince* 2>/dev/null || true
+
+# SBOM hashes trip detect-secrets; not needed at runtime.
+find "${DEST_DIR}" -name '*.cdx.json' -delete
+
+echo "++ Verifying package layout"
+test -x "${DEST_DIR}/prince"
+test -f "${DEST_DIR}/prince-engine/license/license.dat"
+echo "-- OK: Linux AWS Lambda Prince ${PRINCE_VERSION} ready at ${DEST_DIR}"
+echo "   (Cannot --version on macOS; binary is Linux ELF for Lambda.)"
+ls -la "${DEST_DIR}/prince-engine/bin"/prince*

--- a/scripts/fetch-prince-macos.sh
+++ b/scripts/fetch-prince-macos.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Fetch a macOS PrinceXML distribution into services/app-api/bin/prince-arm64
+# for Ministack/AWS emulation on Apple Silicon. Does not touch bin/prince/ (Linux AWS package).
+#
+# Currently unused by LocalStack (which uses fetch-prince-linux.sh); kept for the
+# upcoming ministack conversion.
+#
+# Uses a temporary npm install of the "prince" package (outside this repo's Yarn
+# enableScripts:false) so the native macOS binary can be downloaded.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST_DIR="${REPO_ROOT}/services/app-api/bin/prince-arm64"
+PRINCE_NPM_VERSION="${PRINCE_NPM_VERSION:-1.14.8}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "error: fetch-prince-macos.sh only supports macOS (got $(uname -s))" >&2
+  exit 1
+fi
+
+if [[ "$(uname -m)" != "arm64" ]]; then
+  echo "warning: expected Apple Silicon (arm64); got $(uname -m). Continuing anyway." >&2
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/prince-macos-XXXXXX")"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+echo "++ Installing npm package prince@${PRINCE_NPM_VERSION} in ${TMP_DIR}"
+(
+  cd "${TMP_DIR}"
+  npm install --silent "prince@${PRINCE_NPM_VERSION}"
+  # prince-npm.js skips download if a global prince(1) is on PATH (e.g. Homebrew).
+  # Force a local unpack by hiding other bins during the install script.
+  if [[ ! -x "node_modules/prince/prince/lib/prince/bin/prince" ]]; then
+    echo "++ Running prince-npm.js install to download macOS Prince"
+    NODE_BIN="$(dirname "$(command -v node)")"
+    (
+      cd node_modules/prince
+      # Keep node on PATH; hide Homebrew/other prince(1) so the script downloads locally.
+      PATH="${NODE_BIN}:/usr/bin:/bin" node prince-npm.js install
+    )
+  fi
+)
+
+SRC_PRINCE_DIR="${TMP_DIR}/node_modules/prince/prince"
+BINARY="${SRC_PRINCE_DIR}/lib/prince/bin/prince"
+if [[ ! -f "${BINARY}" ]]; then
+  echo "error: expected binary missing at ${BINARY}" >&2
+  ls -laR "${TMP_DIR}/node_modules/prince" 2>/dev/null | head -80 >&2 || true
+  exit 1
+fi
+
+echo "++ Staging into ${DEST_DIR}"
+rm -rf "${DEST_DIR}"
+mkdir -p "${DEST_DIR}"
+# npm macOS layout: prince/lib/prince/...
+cp -R "${SRC_PRINCE_DIR}/." "${DEST_DIR}/"
+
+# SBOM hashes trip detect-secrets; not needed at runtime.
+find "${DEST_DIR}" -name '*.cdx.json' -delete
+
+# Same runtime interface as the AWS Lambda package: ./prince at package root.
+cat > "${DEST_DIR}/prince" <<'EOF'
+#! /bin/sh
+basedir=$(dirname "$0")
+prefix="${basedir}/lib/prince"
+exec "${prefix}/bin/prince" --prefix="${prefix}" "$@"
+EOF
+
+chmod +x "${DEST_DIR}/prince" "${DEST_DIR}/lib/prince/bin/prince"
+
+echo "++ Verifying"
+"${DEST_DIR}/prince" --version
+echo "-- OK: macOS Prince ready at ${DEST_DIR}"

--- a/scripts/publish-prince-asset.sh
+++ b/scripts/publish-prince-asset.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Download the official YesLogic Prince AWS Lambda zip, verify the pinned SHA-256,
+# and upload it once to the account prerequisites bucket.
+# Note that if you want to download and publish a new version, PRINCE_ASSET_META in
+# deployment/utils/prince-asset.ts must be updated first.
+#
+# Prerequisites:
+#   - Cloudtamer temp creds for the target AWS account
+#   - Bucket already created (deploy prerequisites stack)
+#
+# Usage:
+#   PROJECT=qmr ./scripts/publish-prince-asset.sh
+#   PROJECT=qmr AWS_ACCOUNT_ID=123456789012 ./scripts/publish-prince-asset.sh   <- Ensure you replace with dev/val/main aws account ID
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT="${PROJECT:-qmr}"
+
+read_meta() {
+  (cd "${REPO_ROOT}" && node --import tsx -e "
+    import { loadPrinceAssetMeta } from './deployment/utils/prince-asset.ts';
+    const m = loadPrinceAssetMeta();
+    console.log(m[process.argv[1]]);
+  " "$1")
+}
+
+PRINCE_VERSION="$(read_meta version)"
+EXPECTED_SHA256="$(read_meta sha256)"
+DOWNLOAD_URL="${PRINCE_DOWNLOAD_URL:-$(read_meta url)}"
+
+AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID:-$(aws sts get-caller-identity --query Account --output text)}"
+BUCKET="${PROJECT}-prince-assets-${AWS_ACCOUNT_ID}"
+KEY="prince/${PRINCE_VERSION}/prince-${PRINCE_VERSION}-aws-lambda.zip"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/prince-publish-XXXXXX")"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+ZIP_PATH="${TMP_DIR}/prince-aws-lambda.zip"
+echo "++ Downloading ${DOWNLOAD_URL}"
+curl -fsSL -o "${ZIP_PATH}" "${DOWNLOAD_URL}"
+
+ACTUAL_SHA256="$(shasum -a 256 "${ZIP_PATH}" | awk '{ print $1 }')"
+if [[ "${ACTUAL_SHA256}" != "${EXPECTED_SHA256}" ]]; then
+  echo "error: Prince zip SHA-256 mismatch; refusing to upload" >&2
+  echo "  expected: ${EXPECTED_SHA256}" >&2
+  echo "  actual:   ${ACTUAL_SHA256}" >&2
+  exit 1
+fi
+echo "-- SHA-256 OK (${ACTUAL_SHA256})"
+
+echo "++ Uploading s3://${BUCKET}/${KEY}"
+aws s3 cp "${ZIP_PATH}" "s3://${BUCKET}/${KEY}" \
+  --region "${AWS_DEFAULT_REGION:-us-east-1}"
+
+echo "-- OK: published Prince ${PRINCE_VERSION} to s3://${BUCKET}/${KEY}"

--- a/services/app-api/handlers/prince/pdf.ts
+++ b/services/app-api/handlers/prince/pdf.ts
@@ -1,8 +1,20 @@
+import { spawn } from "node:child_process";
+import { chmodSync, existsSync, statSync } from "node:fs";
+import { join } from "node:path";
 import { gunzipSync } from "node:zlib";
 import handler from "../../libs/handler-lib";
 import { Errors, StatusCodes } from "../../utils/constants/constants";
 import { parseCoreSetParameters } from "../../utils/parseParameters";
 import sanitizeHtml from "sanitize-html";
+
+const PRINCE_TIMEOUT_MS = 10_000;
+// --media=screen matches browser/Chakra styling (DocRaptor print default dropped borders/colors).
+const PRINCE_ARGS = [
+  "-",
+  "--output=-",
+  "--pdf-profile=PDF/UA-1",
+  "--media=screen",
+] as const;
 
 export const getPDF = handler(async (event, _context) => {
   const { allParamsValid } = parseCoreSetParameters(event);
@@ -19,10 +31,6 @@ export const getPDF = handler(async (event, _context) => {
   if (rawBody.startsWith("{")) {
     throw new Error("Body must be base64-encoded HTML, not a JSON object");
   }
-  const { docraptorApiKey, STAGE } = process.env;
-  if (!docraptorApiKey) {
-    throw new Error("No config found to make request to PDF API");
-  }
 
   const compressedBuffer = Buffer.from(rawBody, "base64");
 
@@ -37,47 +45,147 @@ export const getPDF = handler(async (event, _context) => {
   // Use sanitize-html to match previous DOMPurify config, and allow Chakra necessary tags/attributes
   const sanitizedHtml = sanitizeHtml(decodedHtml, buildSanitizationConfig());
 
-  const requestBody = {
-    user_credentials: docraptorApiKey,
-    doc: {
-      document_content: sanitizedHtml,
-      type: "pdf" as const,
-      // This tag differentiates QMR and CARTS requests in DocRaptor's logs.
-      tag: "QMR",
-      test: STAGE !== "production",
-      prince_options: {
-        profile: "PDF/UA-1" as const,
-      },
-    },
-  };
-
-  const arrayBuffer = await sendDocRaptorRequest(requestBody);
-  const base64PdfData = Buffer.from(arrayBuffer).toString("base64");
+  const pdfBuffer = await renderPdfWithPrince(sanitizedHtml);
   return {
     status: StatusCodes.SUCCESS,
-    body: base64PdfData,
+    body: pdfBuffer.toString("base64"),
   };
 });
 
-async function sendDocRaptorRequest(request: DocRaptorRequestBody) {
-  const response = await fetch("https://docraptor.com/docs", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(request),
+function describePrincePackageLayout(taskRoot: string): string {
+  if (existsSync(join(taskRoot, "lib/prince/bin/prince"))) {
+    return "macOS package";
+  }
+  if (
+    existsSync(join(taskRoot, "prince-engine/bin/prince.x86_64")) ||
+    existsSync(join(taskRoot, "prince-engine/bin/prince.aarch64"))
+  ) {
+    return "Linux AWS package";
+  }
+  return "unknown package layout";
+}
+
+/**
+ * Ministack/LocalStack often extracts Lambda zips without preserving +x.
+ * Restore execute bits when missing so spawn("./prince") does not fail with EACCES.
+ */
+function ensurePrinceExecutable(taskRoot: string) {
+  const candidates = [
+    join(taskRoot, "prince"),
+    join(taskRoot, "prince-engine/bin/prince"),
+    join(taskRoot, "prince-engine/bin/prince.x86_64"),
+    join(taskRoot, "prince-engine/bin/prince.aarch64"),
+    join(taskRoot, "lib/prince/bin/prince"),
+  ];
+  for (const filePath of candidates) {
+    if (!existsSync(filePath)) continue;
+    const mode = statSync(filePath).mode;
+    if ((mode & 0o111) === 0) {
+      try {
+        chmodSync(filePath, 0o755);
+      } catch {
+        // /var/task is read-only on real AWS; ignore — zip should already have +x there.
+      }
+    }
+  }
+}
+
+/**
+ * Run the vendored Prince binary against HTML on stdin and return PDF bytes on stdout.
+ * `--pdf-profile=PDF/UA-1` matches the DocRaptor prince_options profile.
+ * `--media=screen` applies screen stylesheets so Chakra form/link chrome renders.
+ */
+export function renderPdfWithPrince(html: string): Promise<Buffer> {
+  const taskRoot = process.env.LAMBDA_TASK_ROOT ?? process.cwd();
+  ensurePrinceExecutable(taskRoot);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("./prince", [...PRINCE_ARGS], {
+      cwd: taskRoot,
+      env: process.env,
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let settled = false;
+
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      fail(new Error("Prince PDF generation timed out"));
+    }, PRINCE_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      fail(
+        new Error(`Failed to spawn Prince in ${taskRoot}: ${error.message}. `)
+      );
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timeout);
+      if (settled) return;
+
+      const pdfBuffer = Buffer.concat(stdoutChunks);
+      const stderr = Buffer.concat(stderrChunks).toString();
+      const hasPdf =
+        pdfBuffer.length > 0 && pdfBuffer.subarray(0, 4).toString() === "%PDF";
+
+      // DocRaptor-like soft-fail: Prince often still emits a PDF while logging
+      // PDF/UA-1 structure errors. Return the PDF and only fail when we got nothing usable.
+      if (stderr) {
+        console.warn(`Prince stderr (exit ${code ?? "unknown"}):\n${stderr}`);
+      }
+
+      if (hasPdf) {
+        settled = true;
+        resolve(pdfBuffer);
+        return;
+      }
+
+      const princeError = stderr.match(/prince:\s+error:\s+([^\n]+)/i);
+      const packageHint = describePrincePackageLayout(taskRoot);
+      const detail = princeError
+        ? princeError[1]
+        : stderr.trim() ||
+          `prince exited with code ${code ?? "unknown"}${
+            signal ? ` signal ${signal}` : ""
+          }`;
+      fail(
+        new Error(
+          `PDF generation failed - ${detail} (${packageHint} in ${taskRoot})`
+        )
+      );
+    });
+
+    if (!child.stdin) {
+      clearTimeout(timeout);
+      fail(new Error("Failed to open Prince stdin"));
+      return;
+    }
+
+    // If Prince dies immediately (wrong arch binary, missing +x, bad license),
+    // stdin write emits EPIPE. Ignore it and let the 'close' handler report stderr.
+    child.stdin.on("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EPIPE" || error.code === "ERR_STREAM_DESTROYED") {
+        return;
+      }
+      clearTimeout(timeout);
+      fail(error);
+    });
+
+    child.stdin.end(html);
   });
-
-  await handlePdfStatusCode(response);
-
-  const pdfPageCount = response.headers.get("X-DocRaptor-Num-Pages");
-  console.debug(`Successfully generated a ${pdfPageCount}-page PDF.`);
-
-  return response.arrayBuffer();
 }
 
 /*
- * These settings are a best-effort to prevent attacks on DocRaptor's servers.
+ * These settings are a best-effort to prevent attacks due to parsing malicious HTML.
  * Since no one but the user making the request will see the resulting PDF,
  * these settings are more relaxed than how we sanitize other API requests.
  * Notably, we allow `style` (tags and attrs), which is normally forbidden.
@@ -87,9 +195,8 @@ async function sendDocRaptorRequest(request: DocRaptorRequestBody) {
  *  - "link" - We use <link> tags to include some styles.
  *  - "base" - The <base> tag tells the renderer to treat relative
  *    URLs (such as <img src="/bar.jpg"/>) as absolute ones (such as
- *    <img src="https://foo.com/bar.jpg"/>). Without this, DocRaptor would
- *    reject our documents; when they render it on their servers, relative
- *    URLs would appear as filesystem access attempts, which they disallow.
+ *    <img src="https://foo.com/bar.jpg"/>). Without this, relative
+ *    URLs can appear as filesystem access attempts.
  *  - "polyline" - This makes checkbox checkmarks visible
  *  - "style" - Chakra UI uses style tags for critical CSS.
  */
@@ -139,80 +246,5 @@ const buildSanitizationConfig = (): sanitizeHtml.IOptions => {
       ...Object.keys(extraAttributes),
       ...extraTags,
     ],
-  };
-};
-
-/**
- * If PDF generation was not successful, log the reason and throw an error.
- *
- * For more details see https://docraptor.com/documentation/api/status_codes
- */
-async function handlePdfStatusCode(response: Response) {
-  if (response.status === 200) {
-    return;
-  }
-
-  const xmlErrorMessage = await response.text();
-  console.warn("DocRaptor Error Message:\n" + xmlErrorMessage);
-
-  switch (response.status) {
-    case 400: // Bad Request
-    case 422: // Unprocessable Entity
-      throw new Error("PDF generation failed - possibly an HTML issue");
-    case 401: // Unauthorized
-    case 403: // Forbidden
-      throw new Error(
-        "PDF generation failed - possibly a configuration or throttle issue"
-      );
-    default:
-      throw new Error(
-        `Received status code ${response.status} from PDF generation service`
-      );
-  }
-}
-
-type DocRaptorRequestBody = {
-  /** Your DocRaptor API key */
-  user_credentials: string;
-  doc: DocRaptorParameters;
-};
-
-/**
- * Here is some in-band documentation for the more common DocRaptor options.
- * There also options for JS handling, asset handling, PDF metadata, and more.
- * Note that we do not use DocRaptor's hosting; we return the PDF directly.
- * For more details see https://docraptor.com/documentation/api
- */
-type DocRaptorParameters = {
-  /** Test documents are watermarked, but don't count against API limits. */
-  test?: boolean;
-  /** We only use `pdf`. */
-  type: "pdf" | "xls" | "xlsx";
-  /** The HTML to render. Either this or `document_url` is required. */
-  document_content?: string;
-  /** The URL to fetch and render. Either this or `document_content` is required. */
-  document_url?: string;
-  /** Synchronous calls have a 60s limit. Callbacks are required for longer-running docs. */
-  async?: boolean;
-  /** This name will show up in the logs: https://docraptor.com/doc_logs */
-  name?: string;
-  /** This tag will also show up in DocRaptor's logs. */
-  tag?: string;
-  /** Should DocRaptor run JS embedded in your HTML? Default is `false`. */
-  javascript?: boolean;
-  prince_options: {
-    /**
-     * In theory we can choose a different PDF version, but UA-1 is the only accessible one.
-     * https://docraptor.com/documentation/article/6637003-accessible-tagged-pdfs
-     */
-    profile: "PDF/UA-1";
-    /** The default is `print`. */
-    media?: "print" | "screen";
-    /** May be needed to load relative urls. Alternatively, use the `<base>` tag. */
-    baseurl?: string;
-    /** The title of your PDF. By default this is the `<title>` of your HTML. */
-    pdf_title?: string;
-    /** This may be used to override the default DPI of `96`. */
-    css_dpi?: number;
   };
 };

--- a/services/app-api/handlers/prince/tests/pdf.test.ts
+++ b/services/app-api/handlers/prince/tests/pdf.test.ts
@@ -1,20 +1,28 @@
-import { getPDF } from "../pdf";
+import { EventEmitter } from "node:events";
+import { gzipSync } from "node:zlib";
+import { Readable, Writable } from "node:stream";
 import { testEvent } from "../../../test-util/testEvents";
 import { Errors, StatusCodes } from "../../../utils/constants/constants";
-import { gzipSync } from "node:zlib";
 
 jest.spyOn(console, "warn").mockImplementation();
 
-global.fetch = jest.fn().mockResolvedValue({
-  status: 200,
-  headers: {
-    get: jest.fn().mockReturnValue("3"),
-  },
-  arrayBuffer: jest.fn().mockResolvedValue(
-    // An ArrayBuffer containing `%PDF-1.7`
-    new Uint8Array([37, 80, 68, 70, 45, 49, 46, 55]).buffer
-  ),
+const mockSpawn = jest.fn();
+
+jest.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+jest.mock("node:fs", () => {
+  const actual = jest.requireActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: jest.fn(() => false),
+    statSync: jest.fn(() => ({ mode: 0o100755 })),
+    chmodSync: jest.fn(),
+  };
 });
+
+import { getPDF } from "../pdf";
 
 const dangerousHtml =
   "<html><head></head><body><p>abc<iframe//src=jAva&Tab;script:alert(3)>def</p></body></html>";
@@ -22,13 +30,80 @@ const compressedHtml = gzipSync(dangerousHtml);
 const sanitizedHtml = "<html><head></head><body><p>abcdef</p></body></html>";
 const base64EncodedDangerousHtml =
   Buffer.from(compressedHtml).toString("base64");
+const mockPdfBytes = Buffer.from("%PDF-1.7");
 
 const event = { ...testEvent };
+
+type MockChild = EventEmitter & {
+  stdout: Readable;
+  stderr: Readable;
+  stdin: Writable;
+  kill: jest.Mock;
+};
+
+function createPrinceChild({
+  stdout,
+  stderr = "",
+  code = 0,
+  epipeOnWrite = false,
+}: {
+  stdout?: Buffer;
+  stderr?: string;
+  code?: number;
+  epipeOnWrite?: boolean;
+}): { child: MockChild; getStdin: () => string } {
+  const chunks: Buffer[] = [];
+  // oxlint-disable-next-line unicorn/prefer-event-target -- Node child_process mock
+  const child = new EventEmitter() as MockChild;
+  child.stdout = new Readable({ read() {} });
+  child.stderr = new Readable({ read() {} });
+  child.kill = jest.fn();
+  child.stdin = new Writable({
+    write(chunk, _encoding, callback) {
+      if (epipeOnWrite) {
+        const error = new Error("write EPIPE") as NodeJS.ErrnoException;
+        error.code = "EPIPE";
+        callback(error);
+        process.nextTick(() => {
+          if (stderr) {
+            child.stderr.push(Buffer.from(stderr));
+          }
+          child.stderr.push(null);
+          child.stdout.push(null);
+          child.emit("close", code);
+        });
+        return;
+      }
+      chunks.push(Buffer.from(chunk));
+      callback();
+    },
+    final(callback) {
+      // Defer close so stdout/stderr data listeners run first
+      if (stdout) {
+        child.stdout.push(stdout);
+      }
+      child.stdout.push(null);
+      if (stderr) {
+        child.stderr.push(Buffer.from(stderr));
+      }
+      child.stderr.push(null);
+      process.nextTick(() => {
+        child.emit("close", code);
+        callback();
+      });
+    },
+  });
+
+  return {
+    child,
+    getStdin: () => Buffer.concat(chunks).toString(),
+  };
+}
 
 describe("Test GetPDF handler", () => {
   beforeEach(() => {
     process.env = {
-      docraptorApiKey: "mock api key", // pragma: allowlist secret
+      LAMBDA_TASK_ROOT: "/var/task",
       STAGE: "dev",
     };
     event.pathParameters = {
@@ -36,6 +111,7 @@ describe("Test GetPDF handler", () => {
       year: "2023",
       coreSet: "CCSC",
     };
+    mockSpawn.mockReset();
   });
 
   afterEach(() => {
@@ -56,16 +132,6 @@ describe("Test GetPDF handler", () => {
 
     expect(res.statusCode).toBe(500);
     expect(res.body).toContain("must be base64-encoded HTML");
-  });
-
-  it("should throw error when config not defined", async () => {
-    delete process.env.docraptorApiKey;
-    event.body = base64EncodedDangerousHtml;
-
-    const res = await getPDF(event, null);
-
-    expect(res.statusCode).toBe(500);
-    expect(res.body).toContain("No config found to make request to PDF API");
   });
 
   it("should throw error when path params are missing", async () => {
@@ -90,48 +156,72 @@ describe("Test GetPDF handler", () => {
     expect(res.body).toContain(Errors.NO_KEY);
   });
 
-  it("should call PDF API with sanitized html", async () => {
+  it("should call Prince with sanitized html and PDF/UA-1 profile", async () => {
+    const { child, getStdin } = createPrinceChild({ stdout: mockPdfBytes });
+    mockSpawn.mockReturnValue(child);
     event.body = base64EncodedDangerousHtml;
-    const res = await getPDF(event, null);
-    expect(res.statusCode).toBe(200);
 
-    expect(fetch).toHaveBeenCalled();
-    const [url, request] = (fetch as jest.Mock).mock.calls[0];
-    const body = JSON.parse(request.body);
-    expect(url).toBe("https://docraptor.com/docs");
-    expect(request).toEqual({
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: expect.stringMatching(/^\{.*\}$/),
-    });
-    expect(body).toEqual({
-      user_credentials: "mock api key", // pragma: allowlist secret
-      doc: expect.objectContaining({
-        document_content: sanitizedHtml,
-        type: "pdf",
-        tag: "QMR",
-        test: true,
-        prince_options: expect.objectContaining({
-          profile: "PDF/UA-1",
-        }),
-      }),
-    });
+    const res = await getPDF(event, null);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toBe(mockPdfBytes.toString("base64"));
+    expect(getStdin()).toBe(sanitizedHtml);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "./prince",
+      ["-", "--output=-", "--pdf-profile=PDF/UA-1", "--media=screen"],
+      expect.objectContaining({ cwd: "/var/task" })
+    );
   });
 
-  it("should handle an error response from the PDF API", async () => {
-    (fetch as jest.Mock).mockResolvedValueOnce({
-      status: 500,
-      text: jest.fn().mockResolvedValue("<error>It broke.</error>"),
+  it("should return PDF when Prince logs UA-1 errors but still emits PDF bytes", async () => {
+    const { child } = createPrinceChild({
+      stdout: mockPdfBytes,
+      stderr:
+        "prince: error: not identifying as PDF/UA-1 due to problems in structure tree\n",
+      code: 0,
     });
+    mockSpawn.mockReturnValue(child);
+    event.body = base64EncodedDangerousHtml;
 
+    const res = await getPDF(event, null);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toBe(mockPdfBytes.toString("base64"));
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("not identifying as PDF/UA-1")
+    );
+  });
+
+  it("should fail when Prince produces no PDF", async () => {
+    const { child } = createPrinceChild({
+      stderr: "prince: error: invalid document",
+      code: 1,
+    });
+    mockSpawn.mockReturnValue(child);
     event.body = base64EncodedDangerousHtml;
 
     const res = await getPDF(event, null);
 
     expect(res.statusCode).toBe(500);
-
+    expect(res.body).toContain("PDF generation failed - invalid document");
     expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining("It broke.")
+      expect.stringContaining("invalid document")
     );
+  });
+
+  it("should not crash with uncaught EPIPE when Prince closes stdin early", async () => {
+    const { child } = createPrinceChild({
+      stderr: "exec format error",
+      code: 126,
+      epipeOnWrite: true,
+    });
+    mockSpawn.mockReturnValue(child);
+    event.body = base64EncodedDangerousHtml;
+
+    const res = await getPDF(event, null);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toContain("PDF generation failed");
+    expect(res.body).not.toContain("EPIPE");
   });
 });

--- a/services/ui-src/local-api-proxy.json
+++ b/services/ui-src/local-api-proxy.json
@@ -1,0 +1,4 @@
+{
+  "gatewayEndpoint": "http://localhost:4566",
+  "apiBasePath": "/_aws/execute-api/390840a8/localstack"
+}

--- a/services/ui-src/src/components/SkipNavigation/index.tsx
+++ b/services/ui-src/src/components/SkipNavigation/index.tsx
@@ -7,7 +7,7 @@ export const SkipNav = () => {
       id="skip-nav-main"
       sx={sx.skipNavLink}
       href={"#main-wrapper"}
-      className="ds-c-skip-nav"
+      className="ds-c-skip-nav hidden-print-items"
     >
       Skip to main content
     </Link>

--- a/services/ui-src/src/views/ExportAll/index.tsx
+++ b/services/ui-src/src/views/ExportAll/index.tsx
@@ -88,6 +88,7 @@ export const ExportAll = () => {
       </CUI.Center>
       <CUI.Center key="buttonGridWrapper" mb="1rem">
         <CUI.SimpleGrid
+          className="prince-measure-link-grid"
           columns={{ base: 2, sm: 3, md: 4, lg: 6, xl: 8 }}
           spacingX={5}
           spacingY={10}

--- a/services/ui-src/src/views/ExportAll/util.test.tsx
+++ b/services/ui-src/src/views/ExportAll/util.test.tsx
@@ -108,6 +108,15 @@ describe("ExportAll utils", () => {
       const countAfter = document.body.querySelectorAll("style").length;
       expect(countAfter).toBe(countBefore + 1);
     });
+
+    it("should include layout overrides for blank pages and measure link grid", () => {
+      applyPrinceSpecificCss();
+      const css = document.body.querySelector("style")?.textContent ?? "";
+      expect(css).toContain("height: auto !important");
+      expect(css).toContain(".prince-measure-link-grid");
+      expect(css).toContain("grid-template-columns: repeat(6");
+      expect(css).toContain("#skip-nav-main");
+    });
   });
 
   describe("cloneEmotionStyles", () => {

--- a/services/ui-src/src/views/ExportAll/util.tsx
+++ b/services/ui-src/src/views/ExportAll/util.tsx
@@ -73,11 +73,56 @@ export const applyPrinceSpecificCss = (): HTMLStyleElement => {
     ${/* Globaly applied tag css */ ""}
     @page {}
     table { table-layout:fixed; width: 100%}
-    html, body, #root { height: 100%; font-size: 16px; }
-    button { display: none !important; visiblity: hidden; }
+    /* height:100% makes Prince treat the root as one page and leaves large blank regions */
+    html, body, #root, #app-wrapper, #main-wrapper {
+      height: auto !important;
+      min-height: 0 !important;
+      max-height: none !important;
+      font-size: 16px;
+    }
+    #app-wrapper, #main-wrapper { display: block !important; }
+    #skip-nav-main, .ds-c-skip-nav { display: none !important; }
+    button { display: none !important; visibility: hidden; }
     td { overflow-wrap: break-word; word-wrap:break-word; white-space: normal; }
     * { box-decoration-break: slice !important; box-sizing: border-box !important; }
     input { padding: 10px 10px 10px 10px !important; min-width: fit-content; word-wrap:break-word; white-space: normal; }
+    input:not([type="checkbox"]):not([type="radio"]),
+    .replaced-text-area {
+      border: 1px solid #718096 !important;
+      border-radius: 6px !important;
+      min-height: 2.5rem !important;
+      background-color: #fff !important;
+    }
+    .chakra-radio__control, .chakra-checkbox__control {
+      border: 1px solid #718096 !important;
+      background-color: #fff !important;
+      width: 1rem !important;
+      height: 1rem !important;
+      vertical-align: middle !important;
+      /* flex keeps Chakra's ::before check/dot centered; inline-block offset it */
+      display: inline-flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      overflow: hidden !important;
+      border-radius: 9999px !important;
+    }
+    .chakra-checkbox__control {
+      border-radius: 2px !important;
+    }
+    .chakra-radio__control[data-checked], .chakra-checkbox__control[data-checked] {
+      background-color: #3182ce !important;
+      border-color: #3182ce !important;
+    }
+    /* Chakra's checked radio draws a white ::before "dot"; with our overrides
+       Prince often places it off-center so it looks like a bite out of the fill. */
+    .chakra-radio__control[data-checked]::before {
+      display: none !important;
+      content: none !important;
+    }
+    a, .chakra-link, .chakra-link * {
+      color: #2b6cb0 !important;
+      text-decoration: underline !important;
+    }
 
     ${/* Adjusted specific component css */ ""}
     .logos { width: 90px; }
@@ -93,15 +138,38 @@ export const applyPrinceSpecificCss = (): HTMLStyleElement => {
     .prince-input-bottom-spacer { margin-bottom: 10px !important; }
     .hidden-print-items { visibility: hidden; display: none !important; }
     .prince-option-label-wrapper { margin-top: 10px; margin: 0 0 10px 0 !important; }
-    .chakra-radio__control, .chakra-checkbox__control { vertical-align: middle !important; }
     .prince-logo-footer { flex-wrap: nowrap; align-content: flex-start; align-items: flex-start; }
     .prince-footer-smaller-text { font-size: var(--chakra-fontSizes-xs); text-align: left; max-width: 100% }
     .prince-flex-row-overwrite { display: flex; flex-direction: row; flex-wrap: nowrap; max-width: 100% !important; margin: 0 0 0 10px }
     .prince-upload-wrapper { text-align: center; display: flex !important; align-content: center; align-items: center; page-break-inside: avoid; }
-    .prince-top-link, .prince-supp-text, h1 { margin: auto !important; text-align: center !important; width: fitcontent !important; margin: 10px 0 !important; }
+    .prince-top-link, .prince-supp-text, h1 { text-align: center !important; width: fit-content !important; margin: 10px 0 !important; }
     .prince-upload-wrapper, .prince-file-item { border: 3px !important; border-style: dotted; background-color: var(--chakra-colors-blue-100); border-radius: var(--chakra-radii-md) }
     .replaced-text-area {border-radius: var(--chakra-radii-md); border-width: 1px; border-style: solid; border-color: inherit; padding: 15px; box-sizing: border-box; white-space: pre-wrap;}
 
+    ${
+      /* Measure TOC links: Emotion/Chakra grid CSS often never makes it into the
+      PDF payload (head styles dropped; :root sheets skipped). Force a fixed grid. */ ""
+    }
+    .prince-measure-link-grid {
+      display: grid !important;
+      grid-template-columns: repeat(6, minmax(0, 1fr)) !important;
+      column-gap: 1.25rem !important;
+      row-gap: 1.5rem !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      margin: 0 auto 1rem auto !important;
+    }
+    .prince-measure-link-grid > a.chakra-button {
+      display: block !important;
+      visibility: visible !important;
+      width: auto !important;
+      text-align: center !important;
+      text-decoration: none !important;
+      color: inherit !important;
+      background: #edf2f7 !important;
+      margin: 0 !important;
+      page-break-inside: avoid;
+    }
 
     ${
       /* ******* Prince doesn't support certain css elements like background colors or css grid out of the box. we have to brute force those styles here.
@@ -156,7 +224,7 @@ export const htmlStringCleanup = (html: string): string => {
   const doc = parser.parseFromString(html, "text/html");
 
   const nodesToRemove = doc.querySelectorAll(
-    `.hidden-print-items, [style*="display: none"], [style*="visibility: hidden"], script, noscript`
+    `#skip-nav-main, .ds-c-skip-nav, .hidden-print-items, [style*="display: none"], [style*="visibility: hidden"], script, noscript`
   );
   for (let node of nodesToRemove) {
     node.remove();


### PR DESCRIPTION
### Description
Switching QMR export PDF function from DocRaptor API call to using the prince binary for document generation.

### Related ticket(s)
CMDCT-6421

---
### How to test
[Deployed Env](https://d1zjggiyb62vto.cloudfront.net/)
Use the deployed cloudfront environment to fill out some measures and then test the export.  If testing locally, ensure you your machine is internet connected prior to running ```./run local``` as it will need to download the prince lambda binaries during the initial cdk deploy.


### Notes
This implementation is still missing a valid Yeslogic/Prince license file so all PDFs will have a prince comment attached to them.  Also note that the current PR downloads the x86 binaries even on an arm based M series mac because Localstack uses Rosetta emulation I believe, but there is a mac script that I will push when we switch over to Ministack.

One additional note, after approval and merge into Main, an Orca team member will need to run the pre-reqs/prince upload step in Val/Prod prior to promotion of this code to high envs.

---
### Pre-review checklist

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist


#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
