### PR TITLE
CMDCT-6306 2026 - BCS-AD Validation

### DIFF
--- a/services/ui-src/src/measures/2026/BCSAD/data.ts
+++ b/services/ui-src/src/measures/2026/BCSAD/data.ts
@@ -60,12 +60,5 @@ export const data: MeasureTemplateData = {
     "validateBothDatesCompleted",
     "validateAtLeastOneDefinitionOfPopulation",
     "validateYearFormat",
-    "validateDualPopInformationPM",
   ],
-  override: {
-    validateDualPopInformationPM: {
-      ageIndex: 2,
-      errorLabel: "Ages 65 to 74",
-    },
-  },
 };

--- a/services/ui-src/src/measures/2026/measureTemplate.test.tsx
+++ b/services/ui-src/src/measures/2026/measureTemplate.test.tsx
@@ -351,9 +351,6 @@ describe("Measure Template tests", () => {
       );
     });
 
-    const dualEligibleMessage =
-      "Information has been included in the Ages 65 to 74 Performance Measure but the checkmark for (Denominator Includes Medicare and Medicaid Dually-Eligible population) is missing";
-
     it("shows 'Ages 65 to 74' dual-eligible warning when ages 65-74 data is present and dual-eligible is unchecked", async () => {
       apiData.useGetMeasureValues.data.Item.data = {
         MeasurementSpecification: "NCQA/HEDIS",
@@ -381,8 +378,6 @@ describe("Measure Template tests", () => {
       await act(() => fireEvent.click(screen.getByText("Validate Measure")));
       // make sure violations are showing
       expect(screen.queryAllByRole("alert")).not.toHaveLength(0);
-      // make sure dual eligible message is one of them
-      expect(screen.queryByText(dualEligibleMessage)).toBeInTheDocument();
     });
 
     it("does not show dual-eligible warning when data is only present for ages 52-64", async () => {
@@ -412,7 +407,6 @@ describe("Measure Template tests", () => {
       await act(() => fireEvent.click(screen.getByText("Validate Measure")));
       // make sure validations are now showing
       expect(screen.queryAllByRole("alert")).not.toHaveLength(0);
-      expect(screen.queryByText(dualEligibleMessage)).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
Removed dualEligible warning message for 2026 BCS-AD form.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-6306

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
[Deploy link](https://d3jtge2duby17s.cloudfront.net/)
Log in as a state user to the application.
Navigate to the 2026 Adult Core Set Measures.
Select the BCS-AD form.
Fill in the form, especially the numerator/denominator for the 65+ age group.
Click the Validate button.
Notice that the form passes validation.

Navigate to the 2025 Adult Core Set Measures.
Select the BCS-AD form.
Fill in the form, especially the numerator/denominator for the 65+ age group.
Click the Validate button.
Notice that the form does not pass validation.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
